### PR TITLE
Warn when a role is being overridden as owner

### DIFF
--- a/lib/DBSteward/dbsteward.php
+++ b/lib/DBSteward/dbsteward.php
@@ -56,7 +56,7 @@ class dbsteward {
   public static $create_languages = FALSE;
   public static $require_slony_id = FALSE;
   public static $output_file_statement_limit = 900;
-  public static $ignore_custom_roles = TRUE;
+  public static $ignore_custom_roles = FALSE;
   // when true, custom roles not found will be turned in to database->role->owner
   public static $require_verbose_interval_notation = FALSE;
   public static $quote_schema_names = FALSE;
@@ -181,6 +181,7 @@ Database definition extraction utilities
       "singlestageupgrade::",
       "maxstatementsperfile::",
       "ignoreoldname::",
+      "ignorecustomroles::",
       "dbdatadiff::",
       "xmlsort::",
       "xmlconvert::"
@@ -226,6 +227,10 @@ Database definition extraction utilities
     
     if (isset($options["ignoreoldname"])) {
       dbsteward::$ignore_oldname = TRUE;
+    }
+
+    if (isset($options["ignorecustomrole"])) {
+      dbsteward::$ignore_custom_roles = TRUE;
     }
     
     if (isset($options["requireslonyid"])) {

--- a/lib/DBSteward/xml_parser.php
+++ b/lib/DBSteward/xml_parser.php
@@ -1161,7 +1161,9 @@ if ( strcasecmp($base['name'], 'app_mode') == 0 && strcasecmp($overlay_cols[$j],
             // this is cleverville:
             // without having to modify the 450000 calls to role_enum
             // return role->owner when a role macro is not found and there is no custom role called $role
-            return $db_doc->database->role->owner;
+            $owner = $db_doc->database->role->owner;
+            dbsteward::console_line(1, "Warning: Ignoring custom roles. Role '$role' is being overridden by ROLE_OWNER ('$owner').");
+            return $owner;
           }
         }
         throw new exception("Unknown role enumeration: " . $role);

--- a/tests/WarnOnOverriddenRoleTest.php
+++ b/tests/WarnOnOverriddenRoleTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests ticket "Warn when a role is being overridden as owner because of ignore_custom_roles flag"
+ * 1) Emit a warning when dbsteward::$ignore_custom_roles = TRUE and the ignoring is happening
+ * 2) add a command line switch to control dbsteward::$ignore_custom_roles
+ * 3) default dbsteward::$ignore_custom_roles to FALSE
+ *
+ * @package DBSteward
+ * @license http://www.opensource.org/licenses/bsd-license.php Simplified BSD License
+ * @author Nicholas J Kiraly <kiraly.nicholas@gmail.com>
+ */
+
+require_once 'PHPUnit/Extensions/OutputTestCase.php';
+require_once __DIR__ . '/../lib/DBSteward/dbsteward.php';
+
+class WarnOnOverriddenRoleTest extends PHPUnit_Extensions_OutputTestCase {
+  public function setUp() {
+    // format doesn't really matter
+    dbsteward::set_sql_format('pgsql8');
+    dbsteward::$quote_schema_names = TRUE;
+    dbsteward::$quote_table_names = TRUE;
+    dbsteward::$quote_column_names = TRUE;
+    dbsteward::$quote_function_names = TRUE;
+    dbsteward::$quote_object_names = TRUE;
+
+    $xml = <<<XML
+<dbsteward>
+  <database>
+    <host>db-host</host>
+    <name>dbsteward</name>
+    <role>
+      <application>dbsteward_phpunit_app</application>
+      <owner>deployment</owner>
+      <replication/>
+      <readonly/>
+      <customRole>custom</customRole>
+    </role>
+  </database>
+</dbsteward>
+XML;
+    $this->dbdoc = new SimpleXMLElement($xml);
+  }
+
+  public function testDefaultValue() {
+    $this->assertFalse(dbsteward::$ignore_custom_roles);
+  }
+
+  public function testWarningWhenTrue() {
+    dbsteward::$ignore_custom_roles = TRUE;
+
+    $role = xml_parser::role_enum($this->dbdoc, 'custom');
+    $this->assertEquals('custom', $role);
+
+    $role = xml_parser::role_enum($this->dbdoc, 'invalid');
+    $this->assertEquals('deployment', $role);
+
+    $this->expectOutputString("[DBSteward-1] Warning: Ignoring custom roles. Role 'invalid' is being overridden by ROLE_OWNER ('deployment').\n");
+  }
+
+  public function testThrowWhenFalse() {
+    dbsteward::$ignore_custom_roles = FALSE;
+
+    try {
+      xml_parser::role_enum($this->dbdoc, 'invalid');
+    }
+    catch (Exception $ex) {
+      $this->assertEquals('Failed to confirm custom role: invalid', $ex->getMessage());
+      return;
+    }
+    $this->fail("Expected exception when not ignoring custom roles");
+  }
+}
+?>


### PR DESCRIPTION
Warn when a role is being overridden as owner because of ignore_custom_roles flag
- Made dbsteward::$ignore_custom_roles default to false
- Added command line option to set it to true
- Print warning about overriding as owner
- Add unit test verifying correct behavior
