### PR TITLE
Fix index dimensions being skipped

### DIFF
--- a/lib/DBSteward/sql_format/mysql5/mysql5.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5.php
@@ -433,9 +433,10 @@ class mysql5 {
           $node_index['using'] = strtolower($db_index->index_type);
           $node_index['unique'] = $db_index->unique ? 'true' : 'false';
 
+          $i = 1;
           foreach ( $db_index->columns as $column_name ) {
             $node_index->addChild('indexDimension', $column_name)
-              ->addAttribute('name','');
+              ->addAttribute('name', $column_name . '_' . $i++);
           }
         }
       }


### PR DESCRIPTION
When the xml_parser makes overlays, it collapses all the dimensions together,
because they all share the same empty name. Solution is to give them dummy
names consisting of column and position.
