### PR TITLE
Re-use composite index for foreign key index if foreign key column is th...

### DIFF
--- a/lib/DBSteward/sql_format/mysql5/mysql5_index.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_index.php
@@ -53,12 +53,13 @@ class mysql5_index extends sql99_index {
         $found = (string)$node_table['primaryKey'] == (string)$column['name'];
         if (!$found) {
           foreach ($nodes as $node) {
-            if (count($node->indexDimension) == 1 && (string)$node->indexDimension[0] == (string)$column['name']) {
+            if ((string)$node->indexDimension[0] == (string)$column['name']) {
               $found = true;
               break;
             }
           }
         }
+ 
         if (!$found) {
           // no? then create one
           $fkey_index = new SimpleXMLElement('<index/>');

--- a/tests/mysql5/Mysql5IndexDiffSQLTest.php
+++ b/tests/mysql5/Mysql5IndexDiffSQLTest.php
@@ -145,6 +145,38 @@ SQL;
     $this->common($this->xml_1a, $this->xml_1b, $expected);
   }
 
+  public function testAddDimension() {
+  $old_xml = <<<XML
+<schema name="oldtest1a" owner="NOBODY">
+  <table name="test" owner="NOBODY">
+    <column name="a" null="false" foreignSchema="test1a" foreignTable="test2" foreignColumn="a" default="0"/>
+    <column name="b"/>
+    <index name="test_idxa" using="hash">
+      <indexDimension name="a_1">a</indexDimension>
+    </index>
+  </table>
+</schema>
+XML;
+  $new_xml = <<<XML
+<schema name="test1a" owner="NOBODY">
+  <table name="test" owner="NOBODY">
+    <column name="a" null="false" foreignSchema="test1a" foreignTable="test2" foreignColumn="a" default="0"/>
+    <column name="b" type="varchar(40)" default="NULL" null="true"/>
+    <index name="test_idxnew" using="btree" unique="false">
+      <indexDimension name="a_1">a</indexDimension>
+      <indexDimension name="b_1">b</indexDimension>
+    </index>
+  </table>
+  <table name="test2">
+    <column name="a"/>
+  </table>
+</schema>
+XML;
+
+    $expected = "ALTER TABLE `test`\n  DROP INDEX `test_idxa`,\n  ADD INDEX `test_idxnew` (`a`, `b`) USING BTREE;";
+    $this->common($old_xml, $new_xml, $expected);
+  }
+
   public function testAddSomeAndChange() {
     $expected = <<<SQL
 ALTER TABLE `test`


### PR DESCRIPTION
Here is what is happening now:
    On initial table creation there is a single index for DeptID (known as DeptINDEX).
    This single index is utilized by mysql for both the foreign key index (which it would implicitly create) as well as the explicitly defined DeptINDEX. There is no reason to have 2 identical indexes so it only allows for definition of one.
    When old and new are diffed, a new index is being created for DeptINDEX because mysql still needs an index for the foreign key. Since it was doing double duty and the xml dropped the explicit definition, we need to make sure the foreign key index is still around.
    This is why it's currently creating that extra index.

This is an improvement that could be made:
    Composite index in mysql can be utilized left to right.
    If the first dimension of a composite index is the name of a foreign key then we don't need to recreate the index for the foreign key as it can utilize the composite index.
    If it's not the first dimension we need the results to be as they currently are since mysql won't magically recreate the foreign key index, we have to tell it to since we dropped it.
