### PR TITLE
Separate illegal/reserved identifier conventions

### DIFF
--- a/lib/DBSteward/dbsteward.php
+++ b/lib/DBSteward/dbsteward.php
@@ -92,6 +92,7 @@ class dbsteward {
   public static $quote_column_names = FALSE;
   public static $quote_all_names = FALSE;
   public static $quote_illegal_identifiers = FALSE;
+  public static $quote_reserved_identifiers = FALSE;
   public static $only_schema_sql = FALSE;
   public static $only_data_sql = FALSE;
   public static $limit_to_tables = array();
@@ -151,6 +152,7 @@ Global Switches and Flags
   --quotecolumnnames                quote column names in SQL output
   --quoteallnames                   quote ALL identifiers in SQL output
   --quoteillegalnames               quote illegal identifiers and treat as a warning, rather than an error.
+  --quotereservednames              quote reserved identifiers and treat as a warning, rather than an error.
 Generating SQL DDL / DML / DCL
   --xml=<database.xml> ...
   --pgdataxml=<pgdata.xml> ...      postgresql SELECT database_to_xml() result to overlay in composite definition
@@ -237,6 +239,7 @@ Format-specific options
       "quotecolumnnames::",
       "quoteallnames::",
       "quoteillegalnames::",
+      "quotereservednames::",
       "onlyschemasql::",
       "onlydatasql::",
       "onlytable::",
@@ -530,6 +533,9 @@ Format-specific options
     }
     if (isset($options["quoteillegalnames"])) {
       dbsteward::$quote_illegal_identifiers = TRUE;
+    }
+    if (isset($options["quotereservednames"])) {
+      dbsteward::$quote_reserved_identifiers = TRUE;
     }
     
     switch ($mode) {

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_index.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_index.php
@@ -32,11 +32,9 @@ class pgsql8_index extends sql99_index {
     }
     $sql .= ' (';
     foreach($node_index->indexDimension AS $dimension) {
-      // if the index dimension is an expression
-      // and not a single token identifier
-      // don't quote the identifier if it's defined as being sql, e.g. '<indexDimension>X + 1</indexDimension>' -> USING ("X + 1")
-      //                                                               '<indexDimension sql="true">X + 1</indexDimension> -> USING(X + 1)
-      if ( !format::is_valid_identifier($dimension) && (isset($dimension['sql']) && strcasecmp($dimension['sql'], 'true') == 0)) {
+      // don't quote the identifier if it's defined as being sql, e.g. '<indexDimension>X + 1</indexDimension>' -> "X + 1"
+      //                                                               '<indexDimension sql="true">X + 1</indexDimension> -> X + 1
+      if ( (isset($dimension['sql']) && strcasecmp($dimension['sql'], 'true') == 0) ) {
         $sql .= $dimension . ', ';
       }
       else {

--- a/tests/IdentifiersTest.php
+++ b/tests/IdentifiersTest.php
@@ -19,29 +19,50 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
     dbsteward::$quote_function_names = FALSE;
     dbsteward::$quote_object_names = FALSE;
     dbsteward::$quote_illegal_identifiers = FALSE;
+    dbsteward::$quote_reserved_identifiers = FALSE;
   }
 
 
   /**
    * @group pgsql8
+   * @group nodb
    * @dataProvider illegalUnquotedPgsql8Identifiers
    */
   public function testPgsql8UnquotedIllegalThrowsIfNotQuotingIllegals($ident) {
     $this->doUnquotedIllegalThrows('pgsql8', $ident);
   }
 
-
   /**
    * @group pgsql8
+   * @group nodb
    * @dataProvider illegalUnquotedPgsql8Identifiers
    */
   public function testPgsql8UnquotedIllegalDoesNotThrowIfQuotingIllegals($ident) {
     $this->doUnquotedIllegalDoesNotThrow('pgsql8', $ident);
   }
 
+  /**
+   * @group pgsql8
+   * @group nodb
+   * @dataProvider reservedPgsql8Identifiers
+   */
+  public function testPgsql8UnquotedReservedThrowsIfNotQuotingReserveds($ident) {
+    $this->doUnquotedReservedThrows('pgsql8', $ident);
+  }
+
+  /**
+   * @group pgsql8
+   * @group nodb
+   * @dataProvider reservedPgsql8Identifiers
+   */
+  public function testPgsql8UnquotedReservedDoesNotThrowIfQuotingReserveds($ident) {
+    $this->doUnquotedReservedDoesNotThrow('pgsql8', $ident);
+  }
+
 
   /**
    * @group mysql5
+   * @group nodb
    * @dataProvider illegalUnquotedMysql5Identifiers
    */
   public function testMysql5UnquotedIllegalThrowsIfNotQuotingIllegals($ident) {
@@ -50,10 +71,29 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
 
   /**
    * @group mysql5
+   * @group nodb
    * @dataProvider illegalUnquotedMysql5Identifiers
    */
   public function testMysql5UnquotedIllegalDoesNotThrowIfQuotingIllegals($ident) {
     $this->doUnquotedIllegalDoesNotThrow('mysql5', $ident);
+  }
+
+  /**
+   * @group mysql5
+   * @group nodb
+   * @dataProvider reservedMysql5Identifiers
+   */
+  public function testMysql5UnquotedReservedThrowsIfNotQuotingReserveds($ident) {
+    $this->doUnquotedReservedThrows('mysql5', $ident);
+  }
+
+  /**
+   * @group mysql5
+   * @group nodb
+   * @dataProvider reservedMysql5Identifiers
+   */
+  public function testMysql5UnquotedReservedDoesNotThrowIfQuotingReserveds($ident) {
+    $this->doUnquotedReservedDoesNotThrow('mysql5', $ident);
   }
 
 
@@ -65,7 +105,7 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
       $quoted = $format::get_quoted_name($ident, FALSE, $format::QUOTE_CHAR);
     }
     catch (Exception $ex) {
-      $this->assertContains('invalid identifier', strtolower($ex->getMessage()));
+      $this->assertContains('illegal identifier', strtolower($ex->getMessage()));
       return;
     }
     $this->fail("Expected an exception when quoting illegal $format identifier '$ident', got no exception, returned $quoted");
@@ -75,6 +115,34 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
   private function doUnquotedIllegalDoesNotThrow($format, $ident) {
     dbsteward::set_sql_format($format);
     dbsteward::$quote_illegal_identifiers = TRUE;
+    $char = $format::QUOTE_CHAR;
+
+    $quoted = $format::get_quoted_name($ident, FALSE, $char);
+    $expected = $char . $ident . $char;
+
+    $this->assertEquals($quoted, $expected);
+
+    // @TODO: check output for warning
+  }
+
+  private function doUnquotedReservedThrows($format, $ident) {
+    dbsteward::set_sql_format($format);
+    dbsteward::$quote_reserved_identifiers = FALSE;
+
+    try {
+      $quoted = $format::get_quoted_name($ident, FALSE, $format::QUOTE_CHAR);
+    }
+    catch (Exception $ex) {
+      $this->assertContains('reserved identifier', strtolower($ex->getMessage()));
+      return;
+    }
+    $this->fail("Expected an exception when quoting reserved $format identifier '$ident', got no exception, returned $quoted");
+  }
+
+
+  private function doUnquotedReservedDoesNotThrow($format, $ident) {
+    dbsteward::set_sql_format($format);
+    dbsteward::$quote_reserved_identifiers = TRUE;
     $char = $format::QUOTE_CHAR;
 
     $quoted = $format::get_quoted_name($ident, FALSE, $char);
@@ -105,13 +173,20 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
   public function illegalUnquotedPgsql8Identifiers() {
     return array_merge(
       $this->illegalUnquotedIdentifiers(),
-      $this->loadBlacklistWords('pgsql8'),
       array(
         array('with$dolla'),
         array('reallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongstringwhywouldsomeonedothis'),
         array('1st_number'), // srsly, why is this valid in mysql?
         array('with"quotechar')
       ));
+  }
+
+  public function reservedPgsql8Identifiers() {
+    return $this->loadBlacklistWords('pgsql8');
+  }
+
+  public function reservedMysql5Identifiers() {
+    return $this->loadBlacklistWords('mysql5');
   }
 
 
@@ -121,7 +196,6 @@ class IdentifiersTest extends PHPUnit_Framework_TestCase {
   public function illegalUnquotedMysql5Identifiers() {
     return array_merge(
       $this->illegalUnquotedIdentifiers(),
-      $this->loadBlacklistWords('mysql5'),
       array(
         array('with`quotechar')
       ));

--- a/tests/regression/QuotedNamesRegressionTest.php
+++ b/tests/regression/QuotedNamesRegressionTest.php
@@ -68,10 +68,10 @@ class QuotedNamesRegressionTest extends PHPUnit_Framework_TestCase {
               call_user_func("$format::get_quoted_{$object}_name",$invalid_name);
             }
             catch ( Exception $ex ) {
-              $this->assertContains('Invalid identifier', $ex->getMessage());
+              $this->assertContains('Illegal identifier', $ex->getMessage());
               continue;
             }
-            $this->fail("Expected 'Invalid identifier' exception, but no exception was thrown for identifier '$invalid_name'");
+            $this->fail("Expected 'Illegal identifier' exception, but no exception was thrown for identifier '$invalid_name'");
           }
         }
 


### PR DESCRIPTION
DBSteward refers to both syntactically illegal identifiers and reserved identifiers as "illegal". This changeset separates the two, adding a new --quotereservednames switch, and erroring about specific infractions.