### PR TITLE
View dependencies & a bunch of random unit test fixes

### DIFF
--- a/lib/DBSteward/dbsteward.dtd
+++ b/lib/DBSteward/dbsteward.dtd
@@ -230,5 +230,6 @@
 <!ATTLIST view owner CDATA #REQUIRED>
 <!ATTLIST view description CDATA #IMPLIED>
 <!ATTLIST view slonySetId CDATA #IMPLIED>
+<!ATTLIST view dependsOnViews CDATA #IMPLIED>
 <!ELEMENT viewQuery (#PCDATA)>
 <!ATTLIST viewQuery sqlFormat CDATA #IMPLIED>

--- a/lib/DBSteward/dbx.php
+++ b/lib/DBSteward/dbx.php
@@ -58,10 +58,18 @@ class dbx {
     return $nodes;
   }
 
-  public static function &get_configuration_parameter(&$node_database, $name, $create_if_not_exist = FALSE) {
-    $nodes = $node_database->xpath("configurationParameter[@name='" . $name . "']");
+  public static function get_configuration_parameter($db_doc, $name, $create_if_not_exist = FALSE) {
+    if ($db_doc == null) {
+      return null;
+    }
+
+    $nodes = $db_doc->xpath("database/configurationParameter[@name='" . $name . "']");
     if (count($nodes) == 0) {
       if ($create_if_not_exist) {
+        $node_database = $db_doc->database;
+        if (empty($node_database)) {
+          $node_database = $db_doc->addChild('configurationParameter');
+        }
         // schema not found, caller wants the schema created in the db
         $node_param = $node_database->addChild('configurationParameter');
         $node_param->addAttribute('name', $name);
@@ -79,12 +87,17 @@ class dbx {
     return $node_param;
   }
 
-  public static function &get_configuration_parameters(&$node_database) {
-    $nodes = $node_database->xpath("configurationParameter");
-    return $nodes;
+  public static function get_configuration_parameters($db_doc) {
+    if ($db_doc == null) {
+      return null;
+    }
+    return $db_doc->xpath("database/configurationParameter");
   }
 
-  public static function &get_schema(&$node_db, $name, $create_if_not_exist = FALSE) {
+  public static function get_schema(&$node_db, $name, $create_if_not_exist = FALSE) {
+    if ($node_db == null && !$create_if_not_exist) {
+      return null;
+    }
     if (!is_object($node_db)) {
       throw new exception("node_db is not an object!");
     }
@@ -643,7 +656,10 @@ class dbx {
     return $nodes;
   }
 
-  public static function &get_view(&$node_schema, $name, $create_if_not_exist = FALSE) {
+  public static function get_view(&$node_schema, $name, $create_if_not_exist = FALSE) {
+    if ($node_schema == null && !$create_if_not_exist) {
+      return null;
+    }
     $nodes = $node_schema->xpath("view[@name='" . $name . "']");
     if (count($nodes) == 0) {
       if ($create_if_not_exist) {
@@ -665,6 +681,9 @@ class dbx {
   }
 
   public static function &get_views(&$node_schema) {
+    if ($node_schema == null) {
+      return array();
+    }
     $nodes = $node_schema->xpath("view");
     return $nodes;
   }

--- a/lib/DBSteward/sql_format/mysql5/mysql5.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5.php
@@ -214,12 +214,11 @@ class mysql5 extends sql99 {
     }
     $ofs->write("\n");
 
-    foreach ( $db_doc->schema as $schema ) {
-      // view creation
-      foreach ($schema->view AS $view) {
-        $ofs->write(mysql5_view::get_creation_sql($schema, $view)."\n");
+    mysql5_diff_views::create_views_ordered($ofs, null, $db_doc);
 
-        // view permission grants
+    // view permission grants
+    foreach ($db_doc->schema as $schema) {
+      foreach ($schema->view AS $view) {
         if (isset($view->grant)) {
           foreach ($view->grant AS $grant) {
             $ofs->write(mysql5_permission::get_permission_sql($db_doc, $schema, $view, $grant) . "\n");

--- a/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
@@ -128,9 +128,6 @@ class mysql5_diff extends sql99_diff {
           if (!in_array(trim($old_schema['name']), $processed_schemas)) {
             // this schema hasn't been processed yet, go ahead and drop views, types, functions, sequences
             // only do it once per schema
-            foreach ($old_schema->view as $node_view) {
-              $ofs->write(mysql5_view::get_drop_sql($old_schema, $node_view) . "\n");
-            }
             foreach ($old_schema->type as $node_type) {
               $ofs->write(mysql5_type::get_drop_sql($old_schema, $node_type) . "\n");
             }
@@ -166,9 +163,6 @@ class mysql5_diff extends sql99_diff {
     else {
       foreach (dbsteward::$old_database->schema as $old_schema) {
         if (!dbx::get_schema(dbsteward::$new_database, $old_schema['name'])) {
-          foreach ($old_schema->view as $node_view) {
-            $ofs->write(mysql5_view::get_drop_sql($old_schema, $node_view) . "\n");
-          }
           foreach ($old_schema->type as $node_type) {
             $ofs->write(mysql5_type::get_drop_sql($old_schema, $node_type) . "\n");
           }

--- a/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
@@ -359,7 +359,7 @@ class mysql5_diff extends sql99_diff {
       }
     }
     
-    mysql5_diff_views::create_views_ordered($ofs1, dbsteward::$old_database, dbsteward::$new_database);
+    mysql5_diff_views::create_views_ordered($ofs3, dbsteward::$old_database, dbsteward::$new_database);
   }
 
   /**

--- a/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_diff.php
@@ -213,12 +213,7 @@ class mysql5_diff extends sql99_diff {
       self::drop_old_schemas($ofs3);
     }
 
-    // drop all views in all schemas, regardless whether dependency order is known or not
-    foreach(dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
-      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
-      $new_schema = dbx::get_schema(dbsteward::$new_database, $new_schema['name']);
-      mysql5_diff_views::drop_views($ofs1, $old_schema, $new_schema);
-    }
+    mysql5_diff_views::drop_views_ordered($ofs1, dbsteward::$old_database, dbsteward::$new_database);
     
     //@TODO: implement mysql5_language ? no relevant conversion exists see other TODO's stating this
     //mysql5_diff_languages::diff_languages($ofs1);
@@ -364,12 +359,7 @@ class mysql5_diff extends sql99_diff {
       }
     }
     
-    // create all views in all schemas, regardless whether dependency order is known or not
-    foreach(dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
-      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
-      $new_schema = dbx::get_schema(dbsteward::$new_database, $new_schema['name']);
-      mysql5_diff_views::create_views($ofs1, $old_schema, $new_schema);
-    }
+    mysql5_diff_views::create_views_ordered($ofs1, dbsteward::$old_database, dbsteward::$new_database);
   }
 
   /**

--- a/lib/DBSteward/sql_format/mysql5/mysql5_diff_views.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_diff_views.php
@@ -9,6 +9,11 @@
  */
 
 class mysql5_diff_views extends sql99_diff_views {
+  public static function should_drop_view($old_schema, $old_view, $new_schema, $new_view) {
+    // unlike sql99_diff_views, *do* drop the view if the new schema doesn't exist,
+    // views aren't dropped with their respective schema
+    // otherwise, drop if it changed or no longer exists
+    return $new_view == null || static::is_view_modified($old_view, $new_view);
+  }
 
 }
-?>

--- a/lib/DBSteward/sql_format/mysql5/mysql5_view.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_view.php
@@ -9,14 +9,14 @@
  */
 
 class mysql5_view extends sql99_view {
-  public static function get_creation_sql($node_schema, $node_view) {
+  public static function get_creation_sql($db_doc, $node_schema, $node_view) {
     if ( isset($node_view['description']) && strlen($node_view['description']) > 0 ) {
       $ddl = "-- {$node_view['description']}\n";
     }
 
     $view_name = mysql5::get_fully_qualified_table_name($node_schema['name'],$node_view['name']);
 
-    $definer = (strlen($node_view['owner']) > 0) ? xml_parser::role_enum(dbsteward::$new_database,$node_view['owner']) : 'CURRENT_USER';
+    $definer = (strlen($node_view['owner']) > 0) ? xml_parser::role_enum($db_doc, $node_view['owner']) : 'CURRENT_USER';
 
     $ddl = "CREATE OR REPLACE DEFINER = $definer SQL SECURITY DEFINER VIEW $view_name\n";
     $ddl.= "  AS " . static::get_view_query($node_view) . ";";

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8.php
@@ -568,12 +568,11 @@ class pgsql8 extends sql99 {
     }
     $ofs->write("\n");
 
-    // view creation
+    pgsql8_diff_views::create_views_ordered($ofs, null, $db_doc);
+
+    // view permission grants
     foreach ($db_doc->schema AS $schema) {
       foreach ($schema->view AS $view) {
-        $ofs->write(pgsql8_view::get_creation_sql($schema, $view));
-
-        // view permission grants
         if (isset($view->grant)) {
           foreach ($view->grant AS $grant) {
             $ofs->write(pgsql8_permission::get_sql($db_doc, $schema, $view, $grant) . "\n");
@@ -584,8 +583,7 @@ class pgsql8 extends sql99 {
     $ofs->write("\n");
 
     // use pgdiff to add any configurationParameters that are defined
-    // dbsteward::$new_database is already set in the caller, build()
-    pgsql8_diff::update_database_config_parameters($ofs);
+    pgsql8_diff::update_database_config_parameters($ofs, null, $db_doc);
   }
 
   public static function build_data($db_doc, $ofs, $tables) {

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_diff.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_diff.php
@@ -172,7 +172,7 @@ class pgsql8_diff extends sql99_diff {
     dbsteward::console_line(1, "Update Permissions");
     self::update_permissions($stage1_ofs, $stage3_ofs);
 
-    self::update_database_config_parameters($stage1_ofs);
+    self::update_database_config_parameters($stage1_ofs, dbsteward::$new_database, dbsteward::$old_database);
 
     dbsteward::console_line(1, "Update Data");
     if (dbsteward::$generate_slonik) {
@@ -221,18 +221,13 @@ class pgsql8_diff extends sql99_diff {
    * @param $ofs1  stage1 output file segmenter
    * @param $ofs3  stage3 output file segmenter
    */
-  private static function update_structure($ofs1, $ofs3) {
+  public static function update_structure($ofs1, $ofs3) {
     $type_modified_columns = array();
     
     pgsql8_diff_languages::diff_languages($ofs1);
     
     // drop all views in all schemas, regardless whether dependency order is known or not
-    foreach(dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
-      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
-      $new_schema = dbx::get_schema(dbsteward::$new_database, $new_schema['name']);
-      pgsql8::set_context_replica_set_id($new_schema);
-      pgsql8_diff_views::drop_views($ofs1, $old_schema, $new_schema);
-    }
+    pgsql8_diff_views::drop_views_ordered($ofs1, dbsteward::$old_database, dbsteward::$new_database);
 
     // if the table dependency order is unknown, bang them in natural order
     if ( ! is_array(self::$new_table_dependency) ) {
@@ -396,13 +391,7 @@ class pgsql8_diff extends sql99_diff {
       }
     }
     
-    // create all views in all schemas, regardless whether dependency order is known or not
-    foreach(dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
-      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
-      $new_schema = dbx::get_schema(dbsteward::$new_database, $new_schema['name']);
-      pgsql8::set_context_replica_set_id($new_schema);
-      pgsql8_diff_views::create_views($ofs3, $old_schema, $new_schema);
-    }
+    pgsql8_diff_views::create_views_ordered($ofs3, dbsteward::$old_database, dbsteward::$new_database);
   }
 
   protected static function update_permissions($ofs1, $ofs3) {
@@ -547,11 +536,11 @@ class pgsql8_diff extends sql99_diff {
    *
    * @return void
    */
-  public static function update_database_config_parameters($ofs) {
-    foreach(dbx::get_configuration_parameters(dbsteward::$new_database->database) AS $new_param) {
+  public static function update_database_config_parameters($ofs, $db_doc_old, $db_doc_new) {
+    foreach(dbx::get_configuration_parameters($db_doc_new) AS $new_param) {
       $old_param = null;
       if ( is_object(dbsteward::$old_database) ) {
-        $old_param = &dbx::get_configuration_parameter(dbsteward::$old_database->database, $new_param['name']);
+        $old_param = &dbx::get_configuration_parameter($db_doc_old, $new_param['name']);
       }
 
       if ( $old_param == null || strcmp($old_param['value'], $new_param['value']) != 0 ) {

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_diff.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_diff.php
@@ -540,7 +540,7 @@ class pgsql8_diff extends sql99_diff {
     foreach(dbx::get_configuration_parameters($db_doc_new) AS $new_param) {
       $old_param = null;
       if ( is_object(dbsteward::$old_database) ) {
-        $old_param = &dbx::get_configuration_parameter($db_doc_old, $new_param['name']);
+        $old_param = dbx::get_configuration_parameter($db_doc_old, $new_param['name']);
       }
 
       if ( $old_param == null || strcmp($old_param['value'], $new_param['value']) != 0 ) {

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_diff_views.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_diff_views.php
@@ -8,42 +8,7 @@
  * @author Nicholas J Kiraly <kiraly.nicholas@gmail.com>
  */
 
-class pgsql8_diff_views {
-
-  /**
-   * Create all new or modified views
-   *
-   * @param $ofs         output file segmenter
-   * @param $old_schema  original schema
-   * @param $new_schema  new schema
-   */
-  public static function create_views($ofs, $old_schema, $new_schema) {
-    foreach (dbx::get_views($new_schema) as $new_view) {
-      if ($old_schema == null
-        || !pgsql8_schema::contains_view($old_schema, $new_view['name'])
-        || self::is_view_modified(dbx::get_view($old_schema, $new_view['name']), $new_view)) {
-        $ofs->write(pgsql8_view::get_creation_sql($new_schema, $new_view));
-      }
-    }
-  }
-
-  /**
-   * Drop all missing or modified views
-   *
-   * @param $ofs         output file segmenter
-   * @param $old_schema  original schema
-   * @param $new_schema  new schema
-   */
-  public static function drop_views($ofs, $old_schema, $new_schema) {
-    if ($old_schema != NULL) {
-      foreach (dbx::get_views($old_schema) as $old_view) {
-        $new_view = dbx::get_view($new_schema, $old_view['name']);
-        if ($new_view == NULL || self::is_view_modified($old_view, $new_view)) {
-          $ofs->write(pgsql8_view::get_drop_sql($old_schema, $old_view) . "\n");
-        }
-      }
-    }
-  }
+class pgsql8_diff_views extends sql99_diff_views {
 
   /**
    * is old_view different than new_view?
@@ -62,5 +27,3 @@ class pgsql8_diff_views {
   }
 
 }
-
-?>

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_view.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_view.php
@@ -8,14 +8,14 @@
  * @author Nicholas J Kiraly <kiraly.nicholas@gmail.com>
  */
 
-class pgsql8_view {
+class pgsql8_view extends sql99_view {
 
   /**
    * Creates and returns SQL for creation of the view.
    *
    * @return string
    */
-  public static function get_creation_sql($node_schema, $node_view) {
+  public static function get_creation_sql($db_doc, $node_schema, $node_view) {
     if ( isset($node_view['description']) && strlen($node_view['description']) > 0 ) {
       $ddl = "-- " . dbsteward::string_cast($node_view['description']) . "\n";
     }
@@ -27,7 +27,7 @@ class pgsql8_view {
 
     if ( isset($node_view['owner']) && strlen($node_view['owner']) > 0 ) {
       $ddl .= "ALTER VIEW " . $view_name
-        . "\n\tOWNER TO " . xml_parser::role_enum(dbsteward::$new_database, $node_view['owner']) . ";\n";
+        . "\n\tOWNER TO " . xml_parser::role_enum($db_doc, $node_view['owner']) . ";\n";
     }
 
     return $ddl;
@@ -43,37 +43,4 @@ class pgsql8_view {
     return $ddl;
   }
 
-  public static function get_view_query($node_view) {
-    $q = '';
-    foreach($node_view->viewQuery AS $query) {
-      if ( !isset($query['sqlFormat']) || strcasecmp($query['sqlFormat'], dbsteward::get_sql_format()) == 0 ) {
-        // sanity check to make sure not more than one viewQuery is matching the sqlFormat scenario
-        if ( strlen($q) > 0 ) {
-          throw new exception("query already matched for sqlFormat -- extra viewQuery elements present?");
-        }
-
-        // sqlFormat is not present or
-        // sqlFormat matches the current static run-time setting
-        // use this viewQuery
-        $q = (string)$query;
-      }
-    }
-
-    if ( strlen($q) == 0 ) {
-      foreach($node_view->viewQuery AS $query) {
-        var_dump($query);
-      }
-      throw new exception("view " . $node_view['name'] . " - failed to find viewQuery that matches active sql format " . dbsteward::get_sql_format());
-    }
-
-    // if last char is ;, prune it
-    if ( substr($q, -1) == ';' ) {
-      $q = substr($q, 0, -1);
-    }
-
-    return $q;
-  }
-
 }
-
-?>

--- a/lib/DBSteward/sql_format/sql99/sql99.php
+++ b/lib/DBSteward/sql_format/sql99/sql99.php
@@ -162,6 +162,8 @@ class sql99 {
   public static function get_fully_qualified_column_name($schema_name, $table_name, $column_name) {
     return static::get_fully_qualified_table_name($schema_name, $table_name) . '.' . static::get_quoted_column_name($column_name);
   }
-}
 
-?>
+  /** No-op. Overridden for pgsql8 slony stuffs */
+  public static function set_context_replica_set_id($obj) {
+  }
+}

--- a/lib/DBSteward/sql_format/sql99/sql99_view.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_view.php
@@ -9,6 +9,13 @@
  */
 
 class sql99_view {
+  public static function get_creation_sql($db_doc, $node_schema, $node_view) {
+    throw new Exception("Not implemented");
+  }
+  public static function get_drop_sql($node_schema, $node_view) {
+    throw new Exception("Not implemented");
+  }
+
   public static function get_view_query($node_view) {
     $q = '';
     foreach($node_view->viewQuery AS $query) {
@@ -39,5 +46,14 @@ class sql99_view {
 
     return $q;
   }
+
+  public static function get_dependencies($node_schema, $node_view) {
+    return array_map(function($s) use ($node_schema) {
+      $parts = explode('.', $s, 2);
+      if (count($parts) == 1) {
+        return array((string)$node_schema['name'], $parts[0]);
+      }
+      return $parts;
+    }, preg_split('/[\,\s]+/', $node_view['dependsOnViews'], -1, PREG_SPLIT_NO_EMPTY));
+  }
 }
-?>

--- a/tests/ViewDependencyOrderTest.php
+++ b/tests/ViewDependencyOrderTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/dbstewardUnitTestBase.php';
 /**
  * @group nodb
  */
-class ColumnDefaultIsFunctionTest extends dbstewardUnitTestBase {
+class ViewDependencyOrderTest extends dbstewardUnitTestBase {
   private $xml = <<<XML
 <dbsteward>
   <database>

--- a/tests/ViewDependencyOrderTest.php
+++ b/tests/ViewDependencyOrderTest.php
@@ -34,7 +34,7 @@ class ColumnDefaultIsFunctionTest extends dbstewardUnitTestBase {
   </database>
 
   <schema name="public" owner="ROLE_OWNER">
-    <view name="view1" owner="ROLE_OWNER">
+    <view name="view1" owner="ROLE_OWNER" dependsOnViews="view2">
       <viewQuery sqlFormat="pgsql8">
         SELECT * FROM view2
       </viewQuery>

--- a/tests/ViewDependencyOrderTest.php
+++ b/tests/ViewDependencyOrderTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests that views are dropped and added in the correct order
+ *
+ * @package DBSteward
+ * @license http://www.opensource.org/licenses/bsd-license.php Simplified BSD License
+ * @author Austin Hyde <austin109@gmail.com>
+ */
+
+require_once __DIR__ . '/dbstewardUnitTestBase.php';
+
+/**
+ * @group nodb
+ */
+class ColumnDefaultIsFunctionTest extends dbstewardUnitTestBase {
+  public function setUp() {
+
+  }
+
+  public function testViewsDroppedAndCreatedInCorrectOrder() {
+    dbsteward::set_sql_format('pgsql8');
+    dbsteward::$quote_all_names = true;
+    pgsql8_diff::$as_transaction = false;
+
+    $xml = <<<XML
+<dbsteward>
+  <database>
+    <role>
+      <application>dbsteward_phpunit_app</application>
+      <owner>deployment</owner>
+      <replication/>
+      <readonly/>
+    </role>
+  </database>
+
+  <schema name="public" owner="ROLE_OWNER">
+    <view name="view1" owner="ROLE_OWNER">
+      <viewQuery sqlFormat="pgsql8">
+        SELECT * FROM view2
+      </viewQuery>
+    </view>
+    <view name="view2" owner="ROLE_OWNER">
+      <viewQuery sqlFormat="pgsql8">
+        SELECT * FROM elsewhere
+      </viewQuery>
+    </view>
+  </schema>
+</dbsteward>
+XML;
+    
+    $actual = $this->doDiff($xml);
+
+    $expected = <<<SQL
+DROP VIEW IF EXISTS "public"."view2";
+DROP VIEW IF EXISTS "public"."view1";
+CREATE OR REPLACE VIEW "public"."view2" AS SELECT * FROM elsewhere;
+ALTER VIEW "public"."view2" OWNER TO deployment;
+CREATE OR REPLACE VIEW "public"."view1" SELECT * FROM view2;
+ALTER VIEW "public"."view1" OWNER TO deployment;
+SQL;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  private function doDiff($xml) {
+    $ofs = new mock_output_file_segmenter();
+
+    dbsteward::$new_database = simplexml_load_string($xml);
+    dbsteward::$old_database = simplexml_load_string($xml);
+    pgsql8_diff::diff_doc_work($ofs, $ofs, $ofs, $ofs);
+
+    $output = $ofs->_get_output();
+
+    return trim(
+            preg_replace('/\n+/', "\n",
+            preg_replace('/ *\n( |\t)+/', ' ',
+            preg_replace('/--.*?\n/', '', $output)))
+          );
+  }
+}

--- a/tests/ViewDependencyOrderTest.php
+++ b/tests/ViewDependencyOrderTest.php
@@ -13,16 +13,7 @@ require_once __DIR__ . '/dbstewardUnitTestBase.php';
  * @group nodb
  */
 class ColumnDefaultIsFunctionTest extends dbstewardUnitTestBase {
-  public function setUp() {
-
-  }
-
-  public function testViewsDroppedAndCreatedInCorrectOrder() {
-    dbsteward::set_sql_format('pgsql8');
-    dbsteward::$quote_all_names = true;
-    pgsql8_diff::$as_transaction = false;
-
-    $xml = <<<XML
+  private $xml = <<<XML
 <dbsteward>
   <database>
     <role>
@@ -35,46 +26,286 @@ class ColumnDefaultIsFunctionTest extends dbstewardUnitTestBase {
 
   <schema name="public" owner="ROLE_OWNER">
     <view name="view1" owner="ROLE_OWNER" dependsOnViews="view2">
-      <viewQuery sqlFormat="pgsql8">
-        SELECT * FROM view2
-      </viewQuery>
+      <viewQuery sqlFormat="pgsql8">SELECT * FROM view2</viewQuery>
+      <viewQuery sqlFormat="mysql5">SELECT * FROM view2</viewQuery>
     </view>
     <view name="view2" owner="ROLE_OWNER">
-      <viewQuery sqlFormat="pgsql8">
-        SELECT * FROM elsewhere
-      </viewQuery>
+      <viewQuery sqlFormat="pgsql8">SELECT * FROM elsewhere</viewQuery>
+      <viewQuery sqlFormat="mysql5">SELECT * FROM elsewhere</viewQuery>
     </view>
   </schema>
 </dbsteward>
 XML;
-    
-    $actual = $this->doDiff($xml);
 
-    $expected = <<<SQL
-DROP VIEW IF EXISTS "public"."view2";
-DROP VIEW IF EXISTS "public"."view1";
-CREATE OR REPLACE VIEW "public"."view2" AS SELECT * FROM elsewhere;
-ALTER VIEW "public"."view2" OWNER TO deployment;
-CREATE OR REPLACE VIEW "public"."view1" SELECT * FROM view2;
-ALTER VIEW "public"."view1" OWNER TO deployment;
-SQL;
+  public function setUp() {
+    dbsteward::$quote_all_names = true;
+    $this->doc = simplexml_load_string($this->xml);
+  }
+
+  /**
+   * @group pgsql8
+   */
+  public function testDependencyOrderingPgsql8() {
+    $this->doTestDependencyOrdering('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testDependencyOrderingMysql5() {
+    $this->doTestDependencyOrdering('mysql5');
+  }
+
+  private function doTestDependencyOrdering($format) {
+    dbsteward::set_sql_format($format);
+
+    $schema = $this->doc->schema;
+    $view1 = $schema->view[0];
+    $view2 = $schema->view[1];
+
+    $arr = array();
+    format_diff_views::with_views_in_order($this->doc, function($schema, $view) use (&$arr) {
+      $arr[] = array($schema, $view);
+    });
+
+    $this->assertCount(2, $arr);
+    $this->assertEquals(array($schema, $view2), $arr[0], 'view2 should be visited before view1');
+    $this->assertEquals(array($schema, $view1), $arr[1], 'view1 should be visited after view2');
+  }
+
+  /**
+   * @group pgsql8
+   */
+  public function testComplexDependencyOrderingPgsql8() {
+    $this->doTestComplexDependencyOrdering('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testComplexDependencyOrderingMysql5() {
+    $this->doTestComplexDependencyOrdering('mysql5');
+  }
+
+  private function doTestComplexDependencyOrdering($format) {
+    dbsteward::set_sql_format($format);
+
+    $xml = <<<XML
+<dbsteward>
+  <schema name="s1">
+    <view name="v1" dependsOnViews="v2,v4" />
+    <view name="v2" dependsOnViews="v3,v5" />
+    <view name="v3" />
+    <view name="v4" dependsOnViews="v5,s2.v3" />
+    <view name="v5" />
+  </schema>
+  <schema name="s2">
+    <view name="v1" />
+    <view name="v2" dependsOnViews="v3,v4,v5" />
+    <view name="v3" />
+    <view name="v4" dependsOnViews="s1.v5" />
+    <view name="v5" />
+  </schema>
+</dbsteward>
+XML;
+    $doc = simplexml_load_string($xml);
+
+    // does an in-order search, so we should see all children, as declared in order, before the parents
+    $expected = array(
+      's1.v3',
+      's1.v5',
+      's1.v2',
+      's2.v3',
+      's1.v4',
+      's1.v1',
+      's2.v1',
+      's2.v4',
+      's2.v5',
+      's2.v2'
+    );
+
+    $actual = array();
+    format_diff_views::with_views_in_order($doc, function ($schema, $view) use (&$actual) {
+      $actual[] = $schema['name'] . '.' . $view['name'];
+    });
 
     $this->assertEquals($expected, $actual);
   }
 
-  private function doDiff($xml) {
+  /**
+   * @group pgsql8
+   */
+  public function testViewsDroppedInOrderPgsql8() {
+    $this->doTestViewsDroppedInOrder('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testViewsDroppedInOrderMysql5() {
+    $this->doTestViewsDroppedInOrder('mysql5');
+  }
+
+  private function doTestViewsDroppedInOrder($format) {
+    dbsteward::set_sql_format($format);
+
+    $doc = $this->doc;
+    $actual = $this->capture(function($ofs) use ($doc) {
+      format_diff_views::drop_views_ordered($ofs, $doc, null);
+    });
+
+    if ($format == 'pgsql8') {
+      $expected = <<<SQL
+DROP VIEW IF EXISTS "public"."view2";
+DROP VIEW IF EXISTS "public"."view1";
+SQL;
+    } else {
+      $expected = <<<SQL
+DROP VIEW IF EXISTS `view2`;
+DROP VIEW IF EXISTS `view1`;
+SQL;
+    }
+    
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @group pgsql8
+   */
+  public function testViewsCreatedInOrderPgsql8() {
+    $this->doTestViewsCreatedInOrder('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testViewsCreatedInOrderMysql5() {
+    $this->doTestViewsCreatedInOrder('mysql5');
+  }
+
+  private function doTestViewsCreatedInOrder($format) {
+    dbsteward::set_sql_format($format);
+
+    $doc = $this->doc;
+    $actual = $this->capture(function($ofs) use ($doc) {
+      format_diff_views::create_views_ordered($ofs, null, $doc);
+    });
+    if ($format == 'pgsql8') {
+      $expected = <<<SQL
+CREATE OR REPLACE VIEW "public"."view2" AS SELECT * FROM elsewhere;
+ALTER VIEW "public"."view2" OWNER TO deployment;
+CREATE OR REPLACE VIEW "public"."view1" AS SELECT * FROM view2;
+ALTER VIEW "public"."view1" OWNER TO deployment;
+SQL;
+    } else {
+      $expected = <<<SQL
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view2` AS SELECT * FROM elsewhere;
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view1` AS SELECT * FROM view2;
+SQL;
+    }
+    
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @group pgsql8
+   */
+  public function testBuildsInOrderPgsql8() {
+    $this->doTestBuildsInOrder('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testBuildsInOrderMysql5() {
+    $this->doTestBuildsInOrder('mysql5');
+  }
+
+  private function doTestBuildsInOrder($format) {
+    dbsteward::set_sql_format($format);
+
+    $doc = $this->doc;
+    $actual = $this->capture(function($ofs) use ($doc) {
+      format::build_schema($doc, $ofs, array());
+    });
+
+    if ($format == 'pgsql8') {
+      $expected = <<<SQL
+CREATE OR REPLACE VIEW "public"."view2" AS SELECT * FROM elsewhere;
+ALTER VIEW "public"."view2" OWNER TO deployment;
+CREATE OR REPLACE VIEW "public"."view1" AS SELECT * FROM view2;
+ALTER VIEW "public"."view1" OWNER TO deployment;
+SQL;
+    } else {
+      $expected = <<<SQL
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view2` AS SELECT * FROM elsewhere;
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view1` AS SELECT * FROM view2;
+SQL;
+    }
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @group pgsql8
+   */
+  public function testUpgradesInOrderPgsql8() {
+    $this->doTestUpgradesInOrder('pgsql8');
+  }
+
+  /**
+   * @group mysql5
+   */
+  public function testUpgradesInOrderMysql5() {
+    $this->doTestUpgradesInOrder('mysql5');
+  }
+
+  private function doTestUpgradesInOrder($format) {
+    dbsteward::set_sql_format($format);
+
+    $doc = $this->doc;
+    $actual = $this->capture(function($ofs) use ($doc) {
+      dbsteward::$new_database = $doc;
+      dbsteward::$old_database = $doc;
+      dbsteward::$single_stage_upgrade = true;
+      format_diff::$as_transaction = false;
+      format_diff::update_structure($ofs, $ofs);
+    });
+
+    if ($format == 'pgsql8') {
+      $expected = <<<SQL
+DROP VIEW IF EXISTS "public"."view2";
+DROP VIEW IF EXISTS "public"."view1";
+CREATE OR REPLACE VIEW "public"."view2" AS SELECT * FROM elsewhere;
+ALTER VIEW "public"."view2" OWNER TO deployment;
+CREATE OR REPLACE VIEW "public"."view1" AS SELECT * FROM view2;
+ALTER VIEW "public"."view1" OWNER TO deployment;
+SQL;
+    } else {
+      $expected = <<<SQL
+DROP VIEW IF EXISTS `view2`;
+DROP VIEW IF EXISTS `view1`;
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view2` AS SELECT * FROM elsewhere;
+CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `view1` AS SELECT * FROM view2;
+SQL;
+    }
+
+    $this->assertEquals($expected, $actual);
+  }
+
+
+  private function capture($callback) {
     $ofs = new mock_output_file_segmenter();
-
-    dbsteward::$new_database = simplexml_load_string($xml);
-    dbsteward::$old_database = simplexml_load_string($xml);
-    pgsql8_diff::diff_doc_work($ofs, $ofs, $ofs, $ofs);
-
-    $output = $ofs->_get_output();
-
+    call_user_func($callback, $ofs);
+    // return $ofs->_get_output();
     return trim(
-            preg_replace('/\n+/', "\n",
-            preg_replace('/ *\n( |\t)+/', ' ',
-            preg_replace('/--.*?\n/', '', $output)))
-          );
+      preg_replace('/\n+/', "\n",
+        preg_replace('/ *\n( |\t)+/', ' ',
+          preg_replace('/-- .*\n/', "\n",
+            $ofs->_get_output()
+          )
+        )
+      )
+    );
   }
 }

--- a/tests/mysql5/Mysql5SchemaDiffTest.php
+++ b/tests/mysql5/Mysql5SchemaDiffTest.php
@@ -339,9 +339,12 @@ XML;
   </table>
 </schema>
 XML;
-    
-    $expected3 = <<<SQL
+
+    $expected1 = <<<SQL
 DROP VIEW IF EXISTS `s2_view`;
+SQL;
+
+    $expected3 = <<<SQL
 -- dropping enum type yesno. references to type yesno will be replaced with the type 'text'
 DROP FUNCTION IF EXISTS `s2_test_concat`;
 DELETE FROM `__sequences` WHERE `name` IN ('the_sequence');
@@ -350,7 +353,7 @@ DELETE FROM `__sequences` WHERE `name` IN ('the_sequence');
 DROP TABLE `s2_table2`;
 SQL;
 
-    $this->diff($old, $new, '', $expected3);
+    $this->diff($old, $new, $expected1, $expected3);
   }
 
   private $db_doc_xml = <<<XML

--- a/tests/mysql5/Mysql5ViewDiffSQLTest.php
+++ b/tests/mysql5/Mysql5ViewDiffSQLTest.php
@@ -164,10 +164,13 @@ XML;
   private function common_drop($xml_a, $xml_b, $expected, $message='') {
     $ofs = new mock_output_file_segmenter();
 
-    $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_a));
-    $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_b));
+    list($old_doc, $old_schema) = $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_a));
+    list($new_doc, $new_schema) = $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_b));
 
     mysql5_diff_views::drop_views_ordered($ofs, dbsteward::$old_database, dbsteward::$new_database);
+    
+    $old_doc->removeChild($old_schema);
+    $new_doc->removeChild($new_schema);
 
     $actual = trim($ofs->_get_output());
 
@@ -177,10 +180,13 @@ XML;
   private function common_create($xml_a, $xml_b, $expected, $message='') {
     $ofs = new mock_output_file_segmenter();
 
-    $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_a));
-    $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_b));
+    list($old_doc, $old_schema) = $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_a));
+    list($new_doc, $new_schema) = $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_b));
 
     mysql5_diff_views::create_views_ordered($ofs, dbsteward::$old_database, dbsteward::$new_database);
+
+    $old_doc->removeChild($old_schema);
+    $new_doc->removeChild($new_schema);
 
     $actual = trim($ofs->_get_output());
 
@@ -191,6 +197,7 @@ XML;
     $parent_node = dom_import_simplexml($parent);
     $child_node = dom_import_simplexml($child);
 
-    $parent_node->appendChild($parent_node->ownerDocument->importNode($child_node, true));
+    $parent_node->appendChild($child_node = $parent_node->ownerDocument->importNode($child_node, true));
+    return array($parent_node, $child_node);
   }
 }

--- a/tests/mysql5/Mysql5ViewDiffSQLTest.php
+++ b/tests/mysql5/Mysql5ViewDiffSQLTest.php
@@ -162,12 +162,12 @@ XML;
 
 
   private function common_drop($xml_a, $xml_b, $expected, $message='') {
-    $schema_a = new SimpleXMLElement($xml_a);
-    $schema_b = new SimpleXMLElement($xml_b);
-
     $ofs = new mock_output_file_segmenter();
 
-    mysql5_diff_views::drop_views($ofs, $schema_a, $schema_b);
+    $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_a));
+    $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_b));
+
+    mysql5_diff_views::drop_views_ordered($ofs, dbsteward::$old_database, dbsteward::$new_database);
 
     $actual = trim($ofs->_get_output());
 
@@ -175,16 +175,22 @@ XML;
   }
 
   private function common_create($xml_a, $xml_b, $expected, $message='') {
-    $schema_a = new SimpleXMLElement($xml_a);
-    $schema_b = new SimpleXMLElement($xml_b);
-
     $ofs = new mock_output_file_segmenter();
 
-    mysql5_diff_views::create_views($ofs, $schema_a, $schema_b);
+    $this->append(dbsteward::$new_database, new SimpleXMLElement($xml_a));
+    $this->append(dbsteward::$old_database, new SimpleXMLElement($xml_b));
+
+    mysql5_diff_views::create_views_ordered($ofs, dbsteward::$old_database, dbsteward::$new_database);
 
     $actual = trim($ofs->_get_output());
 
     $this->assertEquals($expected, $actual, "in create: $message");
   }
+
+  private function append($parent, $child) {
+    $parent_node = dom_import_simplexml($parent);
+    $child_node = dom_import_simplexml($child);
+
+    $parent_node->appendChild($parent_node->ownerDocument->importNode($child_node, true));
+  }
 }
-?>

--- a/tests/mysql5/Mysql5ViewSQLTest.php
+++ b/tests/mysql5/Mysql5ViewSQLTest.php
@@ -52,7 +52,7 @@ XML;
 CREATE OR REPLACE DEFINER = SOMEBODY SQL SECURITY DEFINER VIEW `view`
   AS SELECT * FROM sometable;
 SQL;
-    $actual = trim(preg_replace('/--.*\n?/','',mysql5_view::get_creation_sql($schema, $schema->view)));
+    $actual = trim(preg_replace('/--.*\n?/','',mysql5_view::get_creation_sql(dbsteward::$new_database, $schema, $schema->view)));
     $this->assertEquals($expected, $actual);
 
     $expected = "DROP VIEW IF EXISTS `view`;";
@@ -75,7 +75,7 @@ XML;
 CREATE OR REPLACE DEFINER = SOMEBODY SQL SECURITY DEFINER VIEW `view`
   AS SELECT * FROM mysql5table;
 SQL;
-    $actual = trim(preg_replace('/--.*\n?/','',mysql5_view::get_creation_sql($schema, $schema->view)));
+    $actual = trim(preg_replace('/--.*\n?/','',mysql5_view::get_creation_sql(dbsteward::$new_database, $schema, $schema->view)));
     $this->assertEquals($expected, $actual);
 
     $expected = "DROP VIEW IF EXISTS `view`;";
@@ -92,7 +92,7 @@ XML;
     $schema = new SimpleXMLElement($xml);
 
     try {
-      mysql5_view::get_creation_sql($schema, $schema->view);
+      mysql5_view::get_creation_sql(dbsteward::$new_database, $schema, $schema->view);
     }
     catch ( Exception $ex ) {
       if ( stripos($ex->getMessage(),'failed to find viewquery') === FALSE ) {

--- a/tests/outputDiffTest.php
+++ b/tests/outputDiffTest.php
@@ -243,6 +243,7 @@ XML;
    * @group mysql5
    */
   public function testSerialToIntMysql5() {
+    dbsteward::$single_stage_upgrade = false;
     $this->xml_content_a = $this->mysql5_serial_xml_a;
     $this->xml_file_a = dirname(__FILE__) . '/testdata/type_diff_xml_a.xml';
     file_put_contents($this->xml_file_a, $this->xml_content_a);

--- a/tests/pgsql8/SlonyIdDiffTest.php
+++ b/tests/pgsql8/SlonyIdDiffTest.php
@@ -110,8 +110,11 @@ XML;
   }
   
   public function testGenerateSlonikRemovesTransactionStatements() {
+    pgsql8_diff::$as_transaction = FALSE;
     dbsteward::$generate_slonik = TRUE;
     $this->transaction_statement_check(TRUE);
+
+    pgsql8_diff::$as_transaction = TRUE;
     dbsteward::$generate_slonik = FALSE;
     $this->transaction_statement_check(FALSE);
   }


### PR DESCRIPTION
Allows specifying view dependencies like

```xml
<view name="view_one" dependsOnViews="another_view, other_schema.third_view" ...>
  ...
</view>
```

Diffing and building now respects view dependencies, and always issues `CREATE` and `DROP` DDL for depended-upon views first.

Additionally, fixes a bunch of global-scope/sequence test failures that were cropping up in Travis