### PR TITLE
mysql5 column default removal fix

### DIFF
--- a/lib/DBSteward/sql_format/mysql5/mysql5_diff_tables.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_diff_tables.php
@@ -276,8 +276,8 @@ class mysql5_diff_tables extends sql99_diff_tables {
         $old_column_type = mysql5_column::column_type(dbsteward::$old_database, $old_schema, $old_table, $old_column);
         $new_column_type = mysql5_column::column_type(dbsteward::$new_database, $new_schema, $new_table, $new_column);
 
-        $old_default = isset($old_column['default']) ? $old_column['default'] : '';
-        $new_default = isset($new_column['default']) ? $new_column['default'] : '';
+        $old_default = isset($old_column['default']) ? (string)$old_column['default'] : '';
+        $new_default = isset($new_column['default']) ? (string)$new_column['default'] : '';
 
         $auto_increment_added = !mysql5_column::is_auto_increment($old_column['type']) && mysql5_column::is_auto_increment($new_column['type']);
         $auto_increment_removed = mysql5_column::is_auto_increment($old_column['type']) && !mysql5_column::is_auto_increment($new_column['type']);
@@ -301,7 +301,7 @@ class mysql5_diff_tables extends sql99_diff_tables {
           }
         }
         elseif ($default_changed) {
-          if ($new_default) {
+          if (strlen($new_default) > 0) {
             if (mysql5_column::is_timestamp($new_column)) {
               // timestamps get special treatment
               $cmd1['command'] = 'modify';

--- a/lib/DBSteward/sql_format/sql99/sql99_column.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_column.php
@@ -36,17 +36,23 @@ class sql99_column {
    * @return found default value or null
    */
   public static function get_default_value($type) {
-    $default_value = null;
+    $default_value = NULL;
 
-    if ( preg_match("/^smallint$|^int.*$|^bigint$|^decimal.*$|^numeric.*$|^real$|^double precision$|^float.*$|^double$|^money$/i", $type) > 0 ) {
+    if ( preg_match("/^smallint$|^int.*|^bigint.*|^decimal.*|^numeric.*|^real|^double precision$|^float.*|^double.*|^money.*/i", $type) > 0 ) {
       $default_value = "0";
     }
-    else if ( preg_match("/^character varying.*$|^varchar.*$|^char.*$|^text$/i", $type) > 0 ) {
+    else if ( preg_match("/^character varying.*|^varchar.*|^char.*|^text.*/i", $type) > 0 ) {
       $default_value = "''";
     }
     else if ( preg_match("/^boolean$/i", $type) > 0 ) {
       $default_value = "false";
     }
+    
+    /*
+    if ( $default_value === NULL ) {
+      throw new exception("could not calculate default value for type $type");
+    }
+    /**/
 
     return $default_value;
   }

--- a/tests/mysql5/Mysql5ColumnDefaultTest.php
+++ b/tests/mysql5/Mysql5ColumnDefaultTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * DBSteward unit test for mysql5 column default differencing
+ * 
+ * Unlike Mysql5TableDiffSQLTest.php, this one tests the combination of diffing
+ * constraints, keys, tables, and indexes just like the actual diff engine
+ *
+ * @package DBSteward
+ * @license BSD 2 Clause <http://opensource.org/licenses/BSD-2-Clause>
+ * @author Nicholas Kiraly <kiraly.nicholas@gmail.com>
+ */
+
+require_once __DIR__ . '/../dbstewardUnitTestBase.php';
+
+/**
+ * @group mysql5
+ * @group nodb
+ */
+class Mysql5ColumnDefaultTest extends PHPUnit_Framework_TestCase {
+
+  public function setUp() {
+    dbsteward::set_sql_format('mysql5');
+    dbsteward::$quote_schema_names = TRUE;
+    dbsteward::$quote_table_names = TRUE;
+    dbsteward::$quote_column_names = TRUE;
+    dbsteward::$quote_function_names = TRUE;
+    dbsteward::$quote_object_names = TRUE;
+    dbsteward::$ignore_oldnames = FALSE;
+    mysql5::$use_auto_increment_table_options = FALSE;
+    mysql5::$use_schema_name_prefix = FALSE;
+  }
+
+  private $db_doc_xml = <<<XML
+<dbsteward>
+  <database>
+    <role>
+      <owner>the_owner</owner>
+      <customRole>SOMEBODY</customRole>
+    </role>
+  </database>
+XML;
+
+  public function testDropSetDefault() {
+    $a = <<<XML
+<schema name="public" owner="ROLE_OWNER">
+  <table name="widgets" primaryKey="widgetID" owner="ROLE_OWNER">
+    <column name="widgetID" type="int auto_increment" null="false"/>
+    <column name="widgetName" type="varchar(100)" null="false" />
+    <column name="widgetCreator" type="varchar(100)" null="false" />
+    <column name="order" type="bigint" null="false" default="0"/>
+  </table>
+</schema>
+XML;
+
+    $b = <<<XML
+<schema name="public" owner="ROLE_OWNER">
+  <table name="widgets" primaryKey="widgetID" owner="ROLE_OWNER">
+    <column name="widgetID" type="int auto_increment" null="false"/>
+    <column name="widgetName" type="varchar(100)" null="false" />
+    <column name="widgetCreator" type="varchar(100)" null="false" default="'tstark'" />
+    <column name="order" type="bigint" null="false" />
+  </table>
+</schema>
+XML;
+    
+    // column should have it's default dropped
+    $expected1 = <<<SQL
+ALTER TABLE `widgets`
+  ALTER COLUMN `widgetCreator` SET DEFAULT 'tstark',
+  ALTER COLUMN `order` DROP DEFAULT;
+SQL;
+    $expected3 = '';
+    $this->diff($a, $b, $expected1, $expected3);
+
+    // inverse: column should have default set
+    // note that in mysql5 this is done in stage 1 to take advantage of 
+    // auto not-nulls for columns when setting a default to improve migration performance
+    $expected1 = <<<SQL
+ALTER TABLE `widgets`
+  ALTER COLUMN `order` SET DEFAULT 0,
+  ALTER COLUMN `widgetCreator` DROP DEFAULT;
+SQL;
+    $expected3 = '';
+    
+    $this->diff($b, $a, $expected1, $expected3);
+  }
+
+  private function diff($old, $new, $expected1, $expected3, $message='') {
+    dbsteward::$old_database = new SimpleXMLElement($this->db_doc_xml . $old . '</dbsteward>');
+    dbsteward::$new_database = new SimpleXMLElement($this->db_doc_xml . $new . '</dbsteward>');
+
+    $ofs1 = new mock_output_file_segmenter();
+    $ofs3 = new mock_output_file_segmenter();
+
+    // same structure as mysql5_diff::update_structure
+    foreach (dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
+      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
+
+      mysql5_diff_constraints::diff_constraints($ofs1, $old_schema, $new_schema, 'constraint', TRUE);
+      mysql5_diff_constraints::diff_constraints($ofs1, $old_schema, $new_schema, 'primaryKey', TRUE);
+      mysql5_diff_tables::drop_tables($ofs3, $old_schema, $new_schema);
+      mysql5_diff_tables::diff_tables($ofs1, $ofs3, $old_schema, $new_schema);
+      // mysql5_diff_indexes::diff_indexes($ofs1, $old_schema, $new_schema);
+      mysql5_diff_constraints::diff_constraints($ofs1, $old_schema, $new_schema, 'primaryKey', FALSE);
+    }
+
+    foreach (dbx::get_schemas(dbsteward::$new_database) AS $new_schema) {
+      $old_schema = dbx::get_schema(dbsteward::$old_database, $new_schema['name']);
+      mysql5_diff_constraints::diff_constraints($ofs1, $old_schema, $new_schema, 'constraint', FALSE);
+    }
+
+    $actual1 = trim($ofs1->_get_output());
+    $actual3 = trim($ofs3->_get_output());
+
+    $this->assertEquals($expected1, $actual1, "during stage 1: $message");
+    $this->assertEquals($expected3, $actual3, "during stage 3: $message");
+  }
+}

--- a/tests/mysql5/Mysql5ColumnDefaultTest.php
+++ b/tests/mysql5/Mysql5ColumnDefaultTest.php
@@ -23,11 +23,6 @@ class Mysql5ColumnDefaultTest extends PHPUnit_Framework_TestCase {
     dbsteward::$quote_schema_names = TRUE;
     dbsteward::$quote_table_names = TRUE;
     dbsteward::$quote_column_names = TRUE;
-    dbsteward::$quote_function_names = TRUE;
-    dbsteward::$quote_object_names = TRUE;
-    dbsteward::$ignore_oldnames = FALSE;
-    mysql5::$use_auto_increment_table_options = FALSE;
-    mysql5::$use_schema_name_prefix = FALSE;
   }
 
   private $db_doc_xml = <<<XML
@@ -47,7 +42,7 @@ XML;
     <column name="widgetID" type="int auto_increment" null="false"/>
     <column name="widgetName" type="varchar(100)" null="false" />
     <column name="widgetCreator" type="varchar(100)" null="false" />
-    <column name="order" type="bigint" null="false" default="0"/>
+    <column name="order" type="bigint(11)" null="false" default="0"/>
   </table>
 </schema>
 XML;
@@ -58,7 +53,7 @@ XML;
     <column name="widgetID" type="int auto_increment" null="false"/>
     <column name="widgetName" type="varchar(100)" null="false" />
     <column name="widgetCreator" type="varchar(100)" null="false" default="'tstark'" />
-    <column name="order" type="bigint" null="false" />
+    <column name="order" type="bigint(11)" null="false" />
   </table>
 </schema>
 XML;

--- a/tests/mysql5/Mysql5ColumnDefaultTest.php
+++ b/tests/mysql5/Mysql5ColumnDefaultTest.php
@@ -20,6 +20,7 @@ class Mysql5ColumnDefaultTest extends PHPUnit_Framework_TestCase {
 
   public function setUp() {
     dbsteward::set_sql_format('mysql5');
+    // define_sql_format_default_values sets these like this
     dbsteward::$quote_schema_names = TRUE;
     dbsteward::$quote_table_names = TRUE;
     dbsteward::$quote_column_names = TRUE;
@@ -28,9 +29,10 @@ class Mysql5ColumnDefaultTest extends PHPUnit_Framework_TestCase {
   private $db_doc_xml = <<<XML
 <dbsteward>
   <database>
+    <sqlformat>mysql5</sqlformat>
     <role>
-      <owner>the_owner</owner>
-      <customRole>SOMEBODY</customRole>
+      <application>datapptho</application>
+      <owner>toor</owner>
     </role>
   </database>
 XML;
@@ -39,7 +41,9 @@ XML;
     $a = <<<XML
 <schema name="public" owner="ROLE_OWNER">
   <table name="widgets" primaryKey="widgetID" owner="ROLE_OWNER">
-    <column name="widgetID" type="int auto_increment" null="false"/>
+    <tableOption sqlFormat="mysql5" name="engine" value="InnoDB"/>
+    <tableOption sqlFormat="mysql5" name="default charset" value="latin1"/>
+    <column name="widgetID" type="int(11) AUTO_INCREMENT" null="false"/>
     <column name="widgetName" type="varchar(100)" null="false" />
     <column name="widgetCreator" type="varchar(100)" null="false" />
     <column name="order" type="bigint(11)" null="false" default="0"/>
@@ -50,7 +54,9 @@ XML;
     $b = <<<XML
 <schema name="public" owner="ROLE_OWNER">
   <table name="widgets" primaryKey="widgetID" owner="ROLE_OWNER">
-    <column name="widgetID" type="int auto_increment" null="false"/>
+    <tableOption sqlFormat="mysql5" name="engine" value="InnoDB"/>
+    <tableOption sqlFormat="mysql5" name="default charset" value="latin1"/>
+    <column name="widgetID" type="int(11) AUTO_INCREMENT" null="false"/>
     <column name="widgetName" type="varchar(100)" null="false" />
     <column name="widgetCreator" type="varchar(100)" null="false" default="'tstark'" />
     <column name="order" type="bigint(11)" null="false" />


### PR DESCRIPTION
When a mysql5 column default is removed, the DROP DEFAULT is not used

Added a unit test for truthiness checks of default 0 etc
