### PR TITLE
Drop functions with custom type

### DIFF
--- a/lib/DBSteward/dbx.php
+++ b/lib/DBSteward/dbx.php
@@ -505,6 +505,13 @@ class dbx {
     return $filtered_nodes;
   }
 
+  public static function &get_functions_with_dependent_type(&$node_schema, $name) {
+    return $node_schema->xpath('function/functionParameter[@type="' . $node_schema['name'] . '.' . $name . '"]/..' .
+                               '|function/functionParameter[@type="' . $node_schema['name'] . '.' . $name . '[]" ]/..' .
+                               '|function[@returns="' . $node_schema['name'] . '.' . $name . '"]' .
+                               '|function[@returns="' . $node_schema['name'] . '.' . $name . '[]" ]');
+  }
+
   public static function &get_function_parameter(&$node_function, $name, $create_if_not_exist = FALSE) {
     $nodes = $node_function->xpath("functionParameter[@name='" . $name . "']");
     if (count($nodes) == 0) {

--- a/lib/DBSteward/dbx.php
+++ b/lib/DBSteward/dbx.php
@@ -505,7 +505,7 @@ class dbx {
     return $filtered_nodes;
   }
 
-  public static function &get_functions_with_dependent_type(&$node_schema, $name) {
+  public static function get_functions_with_dependent_type(&$node_schema, $name) {
     return $node_schema->xpath('function/functionParameter[@type="' . $node_schema['name'] . '.' . $name . '"]/..' .
                                '|function/functionParameter[@type="' . $node_schema['name'] . '.' . $name . '[]" ]/..' .
                                '|function[@returns="' . $node_schema['name'] . '.' . $name . '"]' .

--- a/tests/pgsql8/Pgsql8TypeDiffSQLTest.php
+++ b/tests/pgsql8/Pgsql8TypeDiffSQLTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * DBSteward unit test for mysql5 type diffing
+ *
+ * @package DBSteward
+ * @license http://www.opensource.org/licenses/bsd-license.php Simplified BSD License
+ * @author Austin Hyde <austin109@gmail.com>
+ */
+
+require_once __DIR__ . '/../dbstewardUnitTestBase.php';
+
+/**
+ * @group mysql5
+ * @group nodb
+ */
+class Pgsql8TypeDiffSQLTest extends PHPUnit_Framework_TestCase {
+
+  public function setUp() {
+    dbsteward::set_sql_format('pgsql8');
+    dbsteward::$quote_schema_names = TRUE;
+    dbsteward::$quote_table_names = TRUE;
+    dbsteward::$quote_column_names = TRUE;
+    dbsteward::$quote_function_names = TRUE;
+    dbsteward::$quote_object_names = TRUE;
+  }
+
+  public function testChange() {
+    $old = <<<XML
+<schema name="test" owner="ROLE_OWNER">
+  <function name="test_arch_type_in_return" returns="test.arch_type">
+    <functionDefinition language="plpgsql" sqlFormat="pgsql8">
+      BEGIN
+        RETURN 1;
+      END
+    </functionDefinition>
+  </function>
+  <function name="test_arch_type_in_param" returns="bigint">
+    <functionParameter name="testparam" type="test.arch_type" />
+    <functionDefinition language="plpgsql" sqlFormat="pgsql8">
+      BEGIN
+        RETURN 1;
+      END
+    </functionDefinition>
+  </function>
+  <type name="arch_type" type="composite">
+    <typeCompositeElement name="uh_phrasing" type="text"/>
+    <typeCompositeElement name="boom_phrasing" type="text"/>
+  </type>
+</schema>
+XML;
+    $new = <<<XML
+<schema name="test" owner="ROLE_OWNER">
+  <function name="test_arch_type_in_return" returns="test.arch_type">
+    <functionDefinition language="plpgsql" sqlFormat="pgsql8">
+      BEGIN
+        RETURN 1;
+      END
+    </functionDefinition>
+  </function>
+  <function name="test_arch_type_in_param" returns="bigint">
+    <functionParameter name="testparam" type="test.arch_type" />
+    <functionDefinition language="plpgsql" sqlFormat="pgsql8">
+      BEGIN
+        RETURN 1;
+      END
+    </functionDefinition>
+  </function>
+  <type name="arch_type" type="composite">
+    <typeCompositeElement name="uh_phrasing" type="text"/>
+    <typeCompositeElement name="boom_phrasing" type="text"/>
+    <typeCompositeElement name="ummmm_phrasing" type="text"/>
+  </type>
+</schema>
+XML;
+    
+    // just change the name. there shouldn't be any ddl generated, except a note that it was "dropped" and "recreated"
+    $this->common($old, $new, 
+'-- type arch_type definition migration (1/6): dependent functions return/parameter type alteration
+DROP FUNCTION IF EXISTS "test"."test_arch_type_in_return"();
+DROP FUNCTION IF EXISTS "test"."test_arch_type_in_param"(testparam test.arch_type);
+
+-- type arch_type definition migration (2/6): dependent tables column type alteration
+
+-- type arch_type definition migration (3/6): drop old type
+DROP TYPE "test"."arch_type";
+
+-- type arch_type definition migration (4/6): recreate type with new definition
+CREATE TYPE "test"."arch_type" AS (
+  uh_phrasing text,
+  boom_phrasing text,
+  ummmm_phrasing text
+);
+
+-- type arch_type definition migration (5/6): dependent functions return/parameter type with new definition
+CREATE OR REPLACE FUNCTION "test"."test_arch_type_in_return"() RETURNS test.arch_type
+  AS $_$
+
+      BEGIN
+        RETURN 1;
+      END' . "\n    \n\t" . '$_$
+LANGUAGE plpgsql; -- DBSTEWARD_FUNCTION_DEFINITION_END
+
+CREATE OR REPLACE FUNCTION "test"."test_arch_type_in_param"(testparam test.arch_type) RETURNS bigint
+  AS $_$
+
+      BEGIN
+        RETURN 1;
+      END' . "\n    \n\t" . '$_$
+LANGUAGE plpgsql; -- DBSTEWARD_FUNCTION_DEFINITION_END
+
+
+
+-- type arch_type definition migration (6/6): dependent tables type restoration');
+  }
+
+  private function common($xml_a, $xml_b, $expected, $message = NULL) {
+    $schema_a = new SimpleXMLElement($xml_a);
+    $schema_b = new SimpleXMLElement($xml_b);
+
+    $ofs = new mock_output_file_segmenter();
+
+    pgsql8_diff_types::apply_changes($ofs, $schema_a, $schema_b);
+
+    $actual = trim($ofs->_get_output());
+
+    $this->assertEquals($expected, $actual, $message);
+  }
+
+}
+?>


### PR DESCRIPTION
Find functions that depend on a custom type being altered. 

The type can't be dropped and recreated as long as there are functions that depend on it, so drop the functions before doing the type action. Then recreate the functions afterwards.

If there are other modifications to functions they'll be recreated twice, but...oh well.