### PR TITLE
Make foreignSchema optional and default to the current schema

### DIFF
--- a/lib/DBSteward/dbx.php
+++ b/lib/DBSteward/dbx.php
@@ -334,9 +334,8 @@ class dbx {
       foreach ($node_table->column AS $column) {
         // add column foreign key constraints to the list
         if (isset($column['foreignSchema']) || isset($column['foreignTable'])) {
-          if (strlen($column['foreignSchema']) == 0
-            || strlen($column['foreignTable']) == 0) {
-            throw new exception("Invalid foreignSchema|foreignTable pair for " . dbsteward::string_cast($node_schema['name']) . "." . dbsteward::string_cast($node_table['name']) . "." . dbsteward::string_cast($column['name']));
+          if (strlen($column['foreignTable']) == 0) {
+            throw new exception("Invalid foreignTable for " . dbsteward::string_cast($node_schema['name']) . "." . dbsteward::string_cast($node_table['name']) . "." . dbsteward::string_cast($column['name']));
           }
           if (isset($column['type'])
             || strlen($column['type']) > 0) {
@@ -713,7 +712,8 @@ class dbx {
   }
 
   public static function foreign_key($db_doc, $node_schema, $node_table, $column, &$foreign) {
-    $foreign['schema'] = dbx::get_schema($db_doc, $column['foreignSchema']);
+    $fschema = strlen($column['foreignSchema']) == 0 ? (string)$node_schema['name'] : (string)$column['foreignSchema'];
+    $foreign['schema'] = dbx::get_schema($db_doc, $fschema);
     if (!$foreign['schema']) {
       throw new exception("Failed to find foreign schema '" . dbsteward::string_cast($column['foreignSchema']) . "' for " . dbsteward::string_cast($node_schema['name']) . "." . dbsteward::string_cast($node_table['name']) . "." . dbsteward::string_cast($column['name']));
     }

--- a/lib/DBSteward/sql_format/sql99/sql99_constraint.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_constraint.php
@@ -180,9 +180,9 @@ class sql99_constraint {
 
       // look for constraints in columns: foreign key and unique
       foreach ($node_table->column AS $column) {
-        if ( isset($column['foreignSchema']) || isset($column['foreignTable']) ) {
+        if ( isset($column['foreignTable']) ) {
 
-          if ( empty($column['foreignSchema']) || empty($column['foreignTable']) ) {
+          if ( empty($column['foreignTable']) ) {
             throw new Exception("Invalid foreignSchema|foreignTable pair for {$node_schema['name']}.{$node_table['name']}.{$column['name']}");
           }
           if ( ! empty($column['type']) ) {

--- a/lib/DBSteward/sql_format/sql99/sql99_constraint.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_constraint.php
@@ -12,7 +12,9 @@ class sql99_constraint {
 
   public static function foreign_key_lookup($db_doc, $node_schema, $node_table, $column, $visited = array()) {
     $foreign = array();
-    $foreign['schema'] = dbx::get_schema($db_doc, $column['foreignSchema']);
+
+    $fschema = strlen($column['foreignSchema']) == 0 ? (string)$node_schema['name'] : (string)$column['foreignSchema'];
+    $foreign['schema'] = dbx::get_schema($db_doc, $fschema);
     if ( ! $foreign['schema'] ) {
       throw new Exception("Failed to find foreign schema '{$column['foreignSchema']}' for {$node_schema['name']}.{$node_table['name']}.{$column['name']}");
     }

--- a/lib/DBSteward/xml_parser.php
+++ b/lib/DBSteward/xml_parser.php
@@ -879,7 +879,7 @@ if ( strcasecmp($base['name'], 'ponderoustable') == 0 ){
       // column is a foreignKey column ?
       if (isset($column['foreignTable'])) {
         // talking about the same schema?
-        if (strcasecmp($column['foreignSchema'], $b['schema']['name']) == 0) {
+        if (strlen($column['foreignSchema']) === 0 || strcasecmp($column['foreignSchema'], $b['schema']['name']) == 0) {
           // talking about the same table?
           if (strcasecmp($column['foreignTable'], $b['table']['name']) == 0) {
             // so yes, a has a dependency on b via column inline foreign key definition

--- a/tests/OptionalForeignSchemaTest.php
+++ b/tests/OptionalForeignSchemaTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests that columns with foreignTable attributes but not foreignSchema attributes default to the current schema
+ *
+ * @package DBSteward
+ * @license http://www.opensource.org/licenses/bsd-license.php Simplified BSD License
+ * @author Austin Hyde <austin109@gmail.com>
+ */
+
+require_once __DIR__ . '/dbstewardUnitTestBase.php';
+
+class OptionalForeignSchemaTest extends \PHPUnit_Framework_TestCase {
+  /** @group pgsql8 */
+  public function testDbxForeignKeyPgsql8() {
+    dbsteward::set_sql_format('pgsql8');
+    $this->_testDbxForeignKey();
+  }
+  /** @group mysql5 */
+  public function testDbxForeignKeyMysql5() {
+    dbsteward::set_sql_format('mysql5');
+    $this->_testDbxForeignKey();
+  }
+  private function _testDbxForeignKey() {
+    $doc = simplexml_load_string($this->xml);
+    $schema = $doc->schema;
+    $table1 = $schema->table[0];
+    $table1_t1id = $table1->column[0];
+    $table1_t2id = $table1->column[1];
+    $table2 = $schema->table[1];
+    $table2_t2id = $table2->column[0];
+    dbx::foreign_key($doc, $schema, $table1, $table1_t2id, $foreign);
+
+    $this->assertEquals($schema, $foreign['schema']);
+    $this->assertEquals($table2, $foreign['table']);
+    $this->assertEquals($table2_t2id, $foreign['column']);
+  }
+
+  /** @group pgsql8 */
+  public function testXmlParserTableHasDepPgsql8() {
+    dbsteward::set_sql_format('pgsql8');
+    $this->_testXmlParserTableHasDep();
+  }
+  /** @group mysql5 */
+  public function testXmlParserTableHasDepMysql5() {
+    dbsteward::set_sql_format('mysql5');
+    $this->_testXmlParserTableHasDep();
+  }
+  private function _testXmlParserTableHasDep() {
+    $doc = simplexml_load_string($this->xml);
+    $schema = $doc->schema;
+    $table1 = array('schema' => $schema, 'table' => $schema->table[0]);
+    $table2 = array('schema' => $schema, 'table' => $schema->table[1]);
+
+    $this->assertTrue(xml_parser::table_has_dependency($table1, $table2));
+  }
+
+  /** @group pgsql8 */
+  public function testConstraintFKLookupPgsql8() {
+    dbsteward::set_sql_format('pgsql8');
+    $this->_testConstraintFKLookup();
+  }
+  /** @group mysql5 */
+  public function testConstraintFKLookupMysql5() {
+    dbsteward::set_sql_format('mysql5');
+    $this->_testConstraintFKLookup();
+  }
+  private function _testConstraintFKLookup() {
+    $doc = simplexml_load_string($this->xml);
+    $schema = $doc->schema;
+    $table1 = $schema->table[0];
+    $table1_t1id = $table1->column[0];
+    $table1_t2id = $table1->column[1];
+    $table2 = $schema->table[1];
+    $table2_t2id = $table2->column[0];
+    $foreign = format_constraint::foreign_key_lookup($doc, $schema, $table1, $table1_t2id);
+
+    $this->assertEquals($schema, $foreign['schema']);
+    $this->assertEquals($table2, $foreign['table']);
+    $this->assertEquals($table2_t2id, $foreign['column']);
+  }
+
+  private $xml = <<<XML
+<dbsteward>
+  <database>
+    <role>
+      <application>dbsteward_phpunit_app</application>
+      <owner>deployment</owner>
+      <replication/>
+      <readonly/>
+    </role>
+  </database>
+  <schema name="test_schema" owner="ROLE_OWNER">
+    <table name="table1" owner="ROLE_OWNER" primaryKey="table1_id">
+      <column name="table1_id" type="bigserial"/>
+      <column name="table2_id" foreignTable="table2"/>
+    </table>
+    <table name="table2" owner="ROLE_OWNER" primaryKey="table2_id">
+      <column name="table2_id" type="bigserial"/>
+    </table>
+  </schema>
+</dbsteward>
+XML;
+}

--- a/tests/OptionalForeignSchemaTest.php
+++ b/tests/OptionalForeignSchemaTest.php
@@ -79,6 +79,62 @@ class OptionalForeignSchemaTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($table2_t2id, $foreign['column']);
   }
 
+  /** @group pgsql8 */
+  public function testDbxGetTableConstraintsPgsql8() {
+    dbsteward::set_sql_format('pgsql8');
+    $this->_testDbxGetTableConstraints();
+  }
+  /** @group mysql5 */
+  public function testDbxGetTableConstraintsMysql5() {
+    dbsteward::set_sql_format('mysql5');
+    $this->_testDbxGetTableConstraints();
+  }
+  private function _testDbxGetTableConstraints() {
+    $doc = simplexml_load_string($this->xml);
+    $schema = $doc->schema;
+    $table1 = $schema->table[0];
+    $table1_t1id = $table1->column[0];
+    $table1_t2id = $table1->column[1];
+    $table2 = $schema->table[1];
+    $table2_t2id = $table2->column[0];
+
+    $constraints = dbx::get_table_constraints($doc, $schema, $table1, 'foreignKey');
+    $this->assertCount(1, $constraints);
+
+    $foreign = $constraints[0]['foreign_key_data'];
+    $this->assertEquals($schema, $foreign['schema']);
+    $this->assertEquals($table2, $foreign['table']);
+    $this->assertEquals($table2_t2id, $foreign['column']);
+  }
+
+  /** @group pgsql8 */
+  public function testConstraintGetTableConstraintsPgsql8() {
+    dbsteward::set_sql_format('pgsql8');
+    $this->_testConstraintGetTableConstraints();
+  }
+  /** @group mysql5 */
+  public function testConstraintGetTableConstraintsMysql5() {
+    dbsteward::set_sql_format('mysql5');
+    $this->_testConstraintGetTableConstraints();
+  }
+  private function _testConstraintGetTableConstraints() {
+    $doc = simplexml_load_string($this->xml);
+    $schema = $doc->schema;
+    $table1 = $schema->table[0];
+    $table1_t1id = $table1->column[0];
+    $table1_t2id = $table1->column[1];
+    $table2 = $schema->table[1];
+    $table2_t2id = $table2->column[0];
+
+    $constraints = format_constraint::get_table_constraints($doc, $schema, $table1, 'foreignKey');
+    $this->assertCount(1, $constraints);
+
+    $foreign = $constraints[0]['foreign_key_data'];
+    $this->assertEquals($schema, $foreign['schema']);
+    $this->assertEquals($table2, $foreign['table']);
+    $this->assertEquals($table2_t2id, $foreign['column']);
+  }
+
   private $xml = <<<XML
 <dbsteward>
   <database>


### PR DESCRIPTION
Just as the title says, makes foreignSchema default to the current schema if not provided:

```xml
<schema name="test_schema" owner="ROLE_OWNER">
  <table name="table1" owner="ROLE_OWNER" primaryKey="table1_id">
    <column name="table1_id" type="bigserial"/>
    <column name="table2_id" foreignTable="table2"/>
  </table>
  <table name="table2" owner="ROLE_OWNER" primaryKey="table2_id">
    <column name="table2_id" type="bigserial"/>
  </table>
</schema>
```

```sql
-- ...
ALTER TABLE test_schema.table1
  ADD CONSTRAINT table1_table1_id_fkey FOREIGN KEY (table2_id) REFERENCES test_schema.table2(table2_id);
-- ...
```

Includes unit tests confirming/enforcing this behavior.