### PR TITLE
mysql5 doesn't convert boolean columns to tinyint(1)

### DIFF
--- a/lib/DBSteward/sql_format/mysql5/mysql5_column.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5_column.php
@@ -81,7 +81,7 @@ class mysql5_column extends sql99_column {
         $definition .= " DEFAULT CURRENT_TIMESTAMP";
       }
     }
-    else if ( !$nullable && $add_defaults ) {
+    else if ( !$nullable && $add_defaults ) {;
       $default_col_value = self::get_default_value($node_column['type']);
       if ($default_col_value != null) {
         $definition .= " DEFAULT " . $default_col_value;
@@ -129,7 +129,7 @@ class mysql5_column extends sql99_column {
     $type = static::un_auto_increment($node_column['type']);
 
     // if the column type matches an enum type, inject the enum declaration here
-    if ( $node_type = mysql5_type::get_type_node($db_doc, $node_schema, $type) ) {
+    if ( ($node_type = mysql5_type::get_type_node($db_doc, $node_schema, $type)) ) {
      return mysql5_type::get_enum_type_declaration($node_type);
     }
 

--- a/lib/DBSteward/sql_format/sql99/sql99_column.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_column.php
@@ -38,7 +38,7 @@ class sql99_column {
   public static function get_default_value($type) {
     $default_value = NULL;
 
-    if ( preg_match("/^smallint$|^int.*|^bigint.*|^decimal.*|^numeric.*|^real|^double precision$|^float.*|^double.*|^money.*/i", $type) > 0 ) {
+    if ( preg_match("/^smallint$|^(tiny|big)?int.*|^decimal.*|^numeric.*|^real|^double precision$|^float.*|^double.*|^money.*/i", $type) > 0 ) {
       $default_value = "0";
     }
     else if ( preg_match("/^character varying.*|^varchar.*|^char.*|^text.*/i", $type) > 0 ) {

--- a/lib/DBSteward/xml_parser.php
+++ b/lib/DBSteward/xml_parser.php
@@ -1523,7 +1523,10 @@ class xml_parser {
         foreach ($schema->table as $table) {
           foreach ($table->column as $column) {
             if (isset($column['type'])) {
-              list($column['type'], $column['default']) = self::mysql5_type_convert($column['type'], $column['default']);
+              list($column['type'], $d) = self::mysql5_type_convert($column['type'], $column['default']);
+              if (isset($column['default'])) {
+                $column['default'] = $d;
+              }
             }
           }
         }
@@ -1558,7 +1561,7 @@ class xml_parser {
     switch (strtolower($type)) {
       case 'bool':
       case 'boolean':
-        // $type = 'tinyint';
+        $type = 'tinyint(1)';
         if ($value) {
           switch (strtolower($value)) {
             case "'t'":

--- a/tests/mysql5/Mysql5ColumnSQLTest.php
+++ b/tests/mysql5/Mysql5ColumnSQLTest.php
@@ -159,6 +159,7 @@ XML;
 
   public function testTypesAndDefaults() {
     $xml = <<<XML
+<dbsteward>
 <schema name="public" owner="NOBODY">
   <table name="test" primaryKey="id" owner="NOBODY">
     <column name="integer" type="integer" null="false"/>
@@ -170,10 +171,16 @@ XML;
     <column name="text" type="text" null="false"/>
     <column name="varchar80" type="varchar(80)" null="false"/>
     <column name="char" type="char" null="false"/>
+
+    <column name="boolean" type="boolean" null="false"/>
+    <column name="boolean" type="boolean" null="false" default="false"/>
+    <column name="boolean" type="boolean" null="false" default="true"/>
   </table>
 </schema>
+</dbsteward>
 XML;
-    $schema = new SimpleXMLElement($xml);
+    $doc = new SimpleXMLElement($xml);
+    $schema = xml_parser::sql_format_convert($doc)->schema;
 
     $def = function ($col, $add_default, $include_null_def) use (&$schema) {
       return mysql5_column::get_full_definition($schema, $schema, $schema->table, $col, $add_default, $include_null_def);
@@ -187,6 +194,13 @@ XML;
       $col = $schema->table->column[$i];
       $this->assertEquals("`{$col['name']}` {$col['type']} NOT NULL DEFAULT ''", $def($col, true, true));
     }
+
+    $col = $schema->table->column[8];
+    $this->assertEquals("`{$col['name']}` tinyint(1) NOT NULL DEFAULT 0", $def($col, true, true));
+    $col = $schema->table->column[9];
+    $this->assertEquals("`{$col['name']}` tinyint(1) NOT NULL DEFAULT 0", $def($col, true, true));
+    $col = $schema->table->column[10];
+    $this->assertEquals("`{$col['name']}` tinyint(1) NOT NULL DEFAULT 1", $def($col, true, true));
   }
 
   public function testSerials() {


### PR DESCRIPTION
Input:

```xml
<column name="foo" type="boolean" null="false" default="false"/>
```

Expected:
```sql
`foo` tinyint(1) NOT NULL DEFAULT 0
```

Actual:
```sql
`foo` boolean NOT NULL DEFAULT 0
```