### PR TITLE
Misc PHP7 Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.4
 
-dist: precise
+dist: trusty
 sudo: false
 
 env:
@@ -35,6 +36,10 @@ env:
 # branches:
 #   only:
 #     - dev-travis
+
+before_install:
+  # for xmllint
+  - sudo apt-get -y install libxml2-utils
 
 before_script:
   # psql is failing to connect here sometimes, sleep a little

--- a/composer.lock
+++ b/composer.lock
@@ -878,22 +878,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -938,7 +938,11 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26T15:48:44+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+            },
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1585,5 +1589,6 @@
     "platform-dev": {
         "ext-mysqli": "*",
         "ext-pgsql": "*"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }

--- a/lib/DBSteward/dbsteward.php
+++ b/lib/DBSteward/dbsteward.php
@@ -997,7 +997,7 @@ class dbsteward {
     }
     $format_list = array();
     while( ($file = readdir($dh)) !== false ) {
-      if ( strlen($file) > 0 && $file{0} != '.' ) {
+      if ( strlen($file) > 0 && $file[0] != '.' ) {
         if ( is_dir($sql_format_dir . "/" . $file) ) {
           $format_list[] = $file;
         }

--- a/lib/DBSteward/dbsteward.php
+++ b/lib/DBSteward/dbsteward.php
@@ -245,6 +245,18 @@ class dbsteward {
       'pgdata' => array()
     );
 
+    // Somewhere after PHP 5, without these array casts, we get a warning that "Parameter must be an array or an object that implements Countable"
+    if (isset($options['xml'])) {
+      $options['xml'] = (array)$options['xml'];
+    }
+
+    if (isset($options['oldxml'])) {
+      $options['oldxml'] = (array)$options['oldxml'];
+    }
+
+    if (isset($options['newxml'])) {
+      $options['newxml'] = (array)$options['newxml'];
+    }
 
     ///// XML file parameter sanity checks
     if ( isset($options['xml']) ) {

--- a/lib/DBSteward/sql_format/mysql5/mysql5.php
+++ b/lib/DBSteward/sql_format/mysql5/mysql5.php
@@ -264,7 +264,11 @@ class mysql5 extends sql99 {
       $table_primary_keys = mysql5_table::primary_key_columns($table);
       $table_column_names = dbx::to_array($table->column, 'name');
       $node_rows =& dbx::get_table_rows($table); // the <rows> element
-      $data_column_names = preg_split("/,|\s/", $node_rows['columns'], -1, PREG_SPLIT_NO_EMPTY);
+      $columns = "";
+      if ($node_rows) {
+        $columns = $node_rows['columns'];
+      }
+      $data_column_names = preg_split("/,|\s/", $columns, -1, PREG_SPLIT_NO_EMPTY);
 
       // set serial primary keys to the max value after inserts have been performed
       // only if the PRIMARY KEY is not a multi column

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8.php
@@ -2175,30 +2175,30 @@ WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
     for ($i = 0; $i < strlen($input); $i++) {
       //echo "$i, $inquote, $nextval\n";
       if ($inquote) {
-        if ($input{$i} == '"') {
+        if ($input[$i] == '"') {
           $inquote = FALSE;
         }
         else {
-          if ($input{$i} == "\\") {
+          if ($input[$i] == "\\") {
             $i++;
-            $nextval .= $input{$i};
+            $nextval .= $input[$i];
           }
           else {
-            $nextval .= $input{$i};
+            $nextval .= $input[$i];
           }
         }
       }
       else {
-        if ($input{$i} == ',') {
+        if ($input[$i] == ',') {
           $rv[] = $nextval;
           $nextval = '';
         }
         else {
-          if ($input{$i} == '"') {
+          if ($input[$i] == '"') {
             $inquote = TRUE;
           }
           else {
-            $nextval .= $input{$i};
+            $nextval .= $input[$i];
           }
         }
       }

--- a/lib/DBSteward/sql_format/pgsql8/pgsql8_dump_loader.php
+++ b/lib/DBSteward/sql_format/pgsql8/pgsql8_dump_loader.php
@@ -273,7 +273,7 @@ xml_parser::save_xml(dirname(__FILE__) . '/../../../../dbsteward_monitor.xml', $
         if (preg_match(self::PATTERN_END_OF_FUNCTION, $new_line, $matches) > 0) {
           $end_of_function = $matches[1];
 
-          if ($end_of_function{0} == "'") {
+          if ($end_of_function[0] == "'") {
             $end_of_function = "'";
           } else {
             $end_of_function = substr($end_of_function, 0, strpos($end_of_function, '$', 1) + 1);

--- a/lib/DBSteward/sql_format/pgsql8/slony1_slonik.php
+++ b/lib/DBSteward/sql_format/pgsql8/slony1_slonik.php
@@ -19,19 +19,20 @@ class slony1_slonik {
 
     $doc = new SimpleXMLElement('<dbsteward></dbsteward>');
     $line = '';
-    while (($c = fgetc($fp_slonik)) !== FALSE) {
+    $comment = false;
+    while (($c = fgetc($fp_slonik)) !== false) {
       switch ($c) {// catch lines starting with # comments and ignore them
         case '#':
           // only if line hasn't started yet
           if (strlen(trim($line)) == 0) {
-            $comment = TRUE;
+            $comment = true;
           }
         break; // convert newlines to spaces
 
         case "\n":
           $c = ' ';
           // newline encountered, so comment is over
-          $comment = FALSE;
+          $comment = false;
         break; // the statement terminated
 
         case ';':
@@ -46,7 +47,7 @@ class slony1_slonik {
           // late-start # comment line
           $trimmed_line = trim($line);
           if ($trimmed_line[0] == '#') {
-            $comment = TRUE;
+            $comment = true;
           }
           // as long as it isn't a comment
           else if (!$comment) {

--- a/lib/DBSteward/sql_format/pgsql8/slony1_slonik.php
+++ b/lib/DBSteward/sql_format/pgsql8/slony1_slonik.php
@@ -45,7 +45,7 @@ class slony1_slonik {
         default:
           // late-start # comment line
           $trimmed_line = trim($line);
-          if ($trimmed_line{0} == '#') {
+          if ($trimmed_line[0] == '#') {
             $comment = TRUE;
           }
           // as long as it isn't a comment

--- a/lib/DBSteward/sql_format/sql99/sql99_constraint.php
+++ b/lib/DBSteward/sql_format/sql99/sql99_constraint.php
@@ -230,15 +230,11 @@ class sql99_constraint {
             throw new Exception("Primary keys are not allowed to be defined in a <constraint>");
             break;
 
-          default:
-            throw new Exception('unknown constraint type ' . $node_constraint['type'] . ' encountered');
-            break;
-
           case 'CHECK':
           case 'UNIQUE':
             // if we're ONLY looking for foreign keys, ignore everything else
             if ( $type == 'foreignKey' ) {
-              continue;
+              continue 2;
             }
             // fallthru
           case 'FOREIGN KEY':
@@ -249,6 +245,10 @@ class sql99_constraint {
               'type' => strtoupper((string)$node_constraint['type']),
               'definition' => (string)$node_constraint['definition']
             );
+            break;
+
+          default:
+            throw new Exception('unknown constraint type ' . $node_constraint['type'] . ' encountered');
             break;
         }
       }

--- a/tests/mysql5/Mysql5ExtractProcedureTest.php
+++ b/tests/mysql5/Mysql5ExtractProcedureTest.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/Mysql5ExtractionTest.php';
 class Mysql5ExtractProcedureTest extends Mysql5ExtractionTest { 
 
   public function testExtractProcedure() {
-    $sql = <<<SQL
+    $sql = <<<ENDSQL
 DROP PROCEDURE IF EXISTS why_would_i_do_this;
 DELIMITER __;
 CREATE DEFINER = deployment PROCEDURE why_would_i_do_this (IN `str` varchar(25), OUT `len` int(11))
@@ -26,7 +26,7 @@ BEGIN
   SELECT length(str)
     INTO len;
 END;__
-SQL;
+ENDSQL;
 
   $expected = <<<XML
 <function name="why_would_i_do_this" owner="ROLE_OWNER" returns="" description="" procedure="true" cachePolicy="VOLATILE" mysqlEvalType="MODIFIES_SQL_DATA" securityDefiner="true">

--- a/tests/mysql5/Mysql5FunctionDiffSQLTest.php
+++ b/tests/mysql5/Mysql5FunctionDiffSQLTest.php
@@ -182,7 +182,7 @@ XML;
 </schema>
 XML;
 
-  private $create_fn_a = <<<SQL
+  private $create_fn_a = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = the_owner FUNCTION `fn_a` (`arg0` text, `arg1` text)
 RETURNS text
@@ -191,8 +191,8 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
-  private $create_fn_a_own = <<<SQL
+ENDSQL;
+  private $create_fn_a_own = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = SOMEBODY FUNCTION `fn_a` (`arg0` text, `arg1` text)
 RETURNS text
@@ -201,8 +201,8 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
-  private $create_fn_a_argn = <<<SQL
+ENDSQL;
+  private $create_fn_a_argn = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = the_owner FUNCTION `fn_a` (`a` text, `arg1` text)
 RETURNS text
@@ -211,8 +211,8 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
-  private $create_fn_a_argt = <<<SQL
+ENDSQL;
+  private $create_fn_a_argt = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = the_owner FUNCTION `fn_a` (`arg0` int, `arg1` text)
 RETURNS text
@@ -221,8 +221,8 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
-  private $create_fn_a_ret = <<<SQL
+ENDSQL;
+  private $create_fn_a_ret = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = the_owner FUNCTION `fn_a` (`arg0` text, `arg1` text)
 RETURNS int
@@ -231,8 +231,8 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
-  private $create_fn_a_def = <<<SQL
+ENDSQL;
+  private $create_fn_a_def = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
 CREATE DEFINER = the_owner FUNCTION `fn_a` (`arg0` text, `arg1` text)
 RETURNS text
@@ -241,11 +241,11 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN '123';
-SQL;
-  private $drop_fn_a = <<<SQL
+ENDSQL;
+  private $drop_fn_a = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_a`;
-SQL;
-  private $create_fn_b = <<<SQL
+ENDSQL;
+  private $create_fn_b = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_b`;
 CREATE DEFINER = the_owner FUNCTION `fn_b` (`arg0` text, `arg1` text)
 RETURNS text
@@ -254,11 +254,11 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'abc';
-SQL;
-  private $drop_fn_b = <<<SQL
+ENDSQL;
+  private $drop_fn_b = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_b`;
-SQL;
-  private $create_fn_c = <<<SQL
+ENDSQL;
+  private $create_fn_c = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_c`;
 CREATE DEFINER = SOMEBODY FUNCTION `fn_c` (`a` text, `b` text)
 RETURNS text
@@ -267,10 +267,10 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN '123';
-SQL;
-  private $drop_fn_c = <<<SQL
+ENDSQL;
+  private $drop_fn_c = <<<ENDSQL
 DROP FUNCTION IF EXISTS `fn_c`;
-SQL;
+ENDSQL;
 
   public function testNoneToNone() {
     $this->common($this->xml_0, $this->xml_0, '', '');

--- a/tests/mysql5/Mysql5FunctionSQLTest.php
+++ b/tests/mysql5/Mysql5FunctionSQLTest.php
@@ -80,7 +80,7 @@ XML;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -89,7 +89,7 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -112,7 +112,7 @@ END</functionDefinition>
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP PROCEDURE IF EXISTS `why_would_i_do_this`;
 CREATE DEFINER = the_owner PROCEDURE `why_would_i_do_this` (IN `str` varchar(25), OUT `len` int(11))
 LANGUAGE SQL
@@ -123,7 +123,7 @@ BEGIN
   SELECT length(str)
   INTO len;
 END;
-SQL;
+ENDSQL;
 
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -169,7 +169,7 @@ SQL;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -178,7 +178,7 @@ NO SQL
 DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -186,7 +186,7 @@ SQL;
 
     $schema->function['cachePolicy'] = "STABLE";
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -195,7 +195,7 @@ READS SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
 
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -203,7 +203,7 @@ SQL;
 
     $schema->function['cachePolicy'] = "VOLATILE";
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -212,7 +212,7 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
 
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -231,7 +231,7 @@ SQL;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = SOMEBODY FUNCTION `test_fn` ()
 RETURNS text
@@ -240,7 +240,7 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -262,7 +262,7 @@ SQL;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -271,7 +271,7 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY DEFINER
 RETURN 'xyz';
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -323,7 +323,7 @@ XML;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` ENUM('x','y','z'))
 RETURNS ENUM('a','b','c')
@@ -332,7 +332,7 @@ MODIFIES SQL DATA
 NOT DETERMINISTIC
 SQL SECURITY INVOKER
 RETURN 'xyz';
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -420,7 +420,7 @@ END;
 XML;
     $schema = new SimpleXMLElement($xml);
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
 RETURNS text
@@ -437,7 +437,7 @@ BEGIN
     RETURN val;
   END IF;
 END;
-SQL;
+ENDSQL;
     
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
@@ -445,7 +445,7 @@ SQL;
 
     mysql5::$swap_function_delimiters = TRUE;
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 DROP FUNCTION IF EXISTS `test_fn`;
 DELIMITER \$_$
 CREATE DEFINER = CURRENT_USER FUNCTION `test_fn` (`a` text, `b` int, `c` date)
@@ -464,7 +464,7 @@ BEGIN
   END IF;
 END\$_$
 DELIMITER ;
-SQL;
+ENDSQL;
     $actual = trim(mysql5_function::get_creation_sql($schema, $schema->function));
 
     $this->assertEquals($expected, $actual);

--- a/tests/mysql5/Mysql5SQLTest.php
+++ b/tests/mysql5/Mysql5SQLTest.php
@@ -138,7 +138,7 @@ class Mysql5SQLTest extends PHPUnit_Framework_TestCase {
 </dbsteward>
 XML;
 
-    $expected = <<<SQL
+    $expected = <<<ENDSQL
 GRANT SELECT, UPDATE, DELETE ON * TO `deployment`;
 
 DROP FUNCTION IF EXISTS `public_a_function`;
@@ -323,7 +323,7 @@ ALTER TABLE `hotel_rate`
 
 CREATE OR REPLACE DEFINER = deployment SQL SECURITY DEFINER VIEW `public_a_view`
 AS SELECT * FROM user, group;
-SQL;
+ENDSQL;
 
     $dbs = new SimpleXMLElement($xml);
     $ofs = new mock_output_file_segmenter();

--- a/tests/mysql5/Mysql5SchemaSQLTest.php
+++ b/tests/mysql5/Mysql5SchemaSQLTest.php
@@ -54,7 +54,7 @@ class Mysql5SchemaSQLTest extends PHPUnit_Framework_TestCase {
 </dbsteward>
 XML;
 
-    $expected = <<<'SQL'
+    $expected = <<<'ENDSQL'
 DROP FUNCTION IF EXISTS `function1`;
 DELIMITER $_$
 CREATE DEFINER = CURRENT_USER FUNCTION `function1` (`a` text, `b` int, `c` date)
@@ -74,7 +74,7 @@ CREATE TABLE `table1` (
 ALTER TABLE `table1`
   ADD PRIMARY KEY (`col1`);
 
-SQL;
+ENDSQL;
     
     $this->common($xml, $expected);
   }
@@ -120,7 +120,7 @@ SQL;
 </dbsteward>
 XML;
 
-    $expected = <<<'SQL'
+    $expected = <<<'ENDSQL'
 DROP FUNCTION IF EXISTS `schema1_function1`;
 DELIMITER $_$
 CREATE DEFINER = CURRENT_USER FUNCTION `schema1_function1` (`a` text, `b` int, `c` date)
@@ -252,7 +252,7 @@ ALTER TABLE `schema2_table2`
 
 CREATE OR REPLACE DEFINER = the_owner SQL SECURITY DEFINER VIEW `schema2_view`
   AS SELECT * FROM table2;
-SQL;
+ENDSQL;
     
     $this->common($xml, $expected);
   }

--- a/tests/mysql5/Mysql5TableSQLTest.php
+++ b/tests/mysql5/Mysql5TableSQLTest.php
@@ -152,7 +152,7 @@ XML;
 
     // check that we validate the number of partitions
     $table->tablePartition->tablePartitionOption[0]['value'] = 'id';
-    $table->tablePartition->tablePartitionOption[1]['value'] = 'x';
+    $table->tablePartition->tablePartitionOption[1]['value'] = '-1';
     $this->expect("tablePartitionOption 'number' must be an integer greater than 0", $get_sql);
 
     // check that using an expression does NOT quote the value
@@ -195,7 +195,7 @@ XML;
 
     // check that we validate the number of partitions
     $table->tablePartition->tablePartitionOption[0]['value'] = 'id';
-    $table->tablePartition->tablePartitionOption[1]['value'] = 'x';
+    $table->tablePartition->tablePartitionOption[1]['value'] = '-1';
     $this->expect("tablePartitionOption 'number' must be an integer greater than 0", $get_sql);
 
     // check that using an expression does NOT quote the value


### PR DESCRIPTION
Fixes a few problems with dbsteward under PHP 7.4. All the fixes should work just fine under PHP 5.5+, to be validated by travis.

- Updated travis to check PHP 7.4
- Fixed problematic heredocs (something in php parsing changed, I guess)
- Fixed curly-brace access like `$foo{$bar}` to the standard `$foo[$bar]`
- Fixed an undefined variable warning
- Fixed issues with getopt suddenly breaking `count()`
- Fixed a `continue` inside a loop+switch that wasn't continuing the loop, just breaking the switch
- Fixed some cases where we were accessing a null/bool as an array
- Fixed some mysql tests that have different errors under newer PHP